### PR TITLE
Fix notification icon

### DIFF
--- a/src/gnome-shell/3.26/gnome-shell-compact.css
+++ b/src/gnome-shell/3.26/gnome-shell-compact.css
@@ -1087,6 +1087,14 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: #FFFFFF;
 }
 
+#panel .panel-button.clock-display > StBoxLayout > StIcon {
+  color: rgba(255, 64, 129, 0.7);
+}
+
+#panel .panel-button.clock-display:hover > StBoxLayout > StIcon, #panel .panel-button.clock-display:active > StBoxLayout > StIcon {
+  color: #FF4081;
+}
+
 #panel .panel-status-indicators-box,
 #panel .panel-status-menu-box {
   spacing: 2px;

--- a/src/gnome-shell/3.26/gnome-shell-dark-compact.css
+++ b/src/gnome-shell/3.26/gnome-shell-dark-compact.css
@@ -1087,6 +1087,14 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: #FFFFFF;
 }
 
+#panel .panel-button.clock-display > StBoxLayout > StIcon {
+  color: rgba(255, 64, 129, 0.7);
+}
+
+#panel .panel-button.clock-display:hover > StBoxLayout > StIcon, #panel .panel-button.clock-display:active > StBoxLayout > StIcon {
+  color: #FF4081;
+}
+
 #panel .panel-status-indicators-box,
 #panel .panel-status-menu-box {
   spacing: 2px;

--- a/src/gnome-shell/3.26/gnome-shell-dark.css
+++ b/src/gnome-shell/3.26/gnome-shell-dark.css
@@ -1087,6 +1087,14 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: #FFFFFF;
 }
 
+#panel .panel-button.clock-display > StBoxLayout > StIcon {
+  color: rgba(255, 64, 129, 0.7);
+}
+
+#panel .panel-button.clock-display:hover > StBoxLayout > StIcon, #panel .panel-button.clock-display:active > StBoxLayout > StIcon {
+  color: #FF4081;
+}
+
 #panel .panel-status-indicators-box,
 #panel .panel-status-menu-box {
   spacing: 2px;

--- a/src/gnome-shell/3.26/gnome-shell-light-compact.css
+++ b/src/gnome-shell/3.26/gnome-shell-light-compact.css
@@ -1087,6 +1087,14 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: #FFFFFF;
 }
 
+#panel .panel-button.clock-display > StBoxLayout > StIcon {
+  color: rgba(255, 64, 129, 0.7);
+}
+
+#panel .panel-button.clock-display:hover > StBoxLayout > StIcon, #panel .panel-button.clock-display:active > StBoxLayout > StIcon {
+  color: #FF4081;
+}
+
 #panel .panel-status-indicators-box,
 #panel .panel-status-menu-box {
   spacing: 2px;

--- a/src/gnome-shell/3.26/gnome-shell-light.css
+++ b/src/gnome-shell/3.26/gnome-shell-light.css
@@ -1087,6 +1087,14 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: #FFFFFF;
 }
 
+#panel .panel-button.clock-display > StBoxLayout > StIcon {
+  color: rgba(255, 64, 129, 0.7);
+}
+
+#panel .panel-button.clock-display:hover > StBoxLayout > StIcon, #panel .panel-button.clock-display:active > StBoxLayout > StIcon {
+  color: #FF4081;
+}
+
 #panel .panel-status-indicators-box,
 #panel .panel-status-menu-box {
   spacing: 2px;

--- a/src/gnome-shell/3.26/gnome-shell.css
+++ b/src/gnome-shell/3.26/gnome-shell.css
@@ -1087,6 +1087,14 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: #FFFFFF;
 }
 
+#panel .panel-button.clock-display > StBoxLayout > StIcon {
+  color: rgba(255, 64, 129, 0.7);
+}
+
+#panel .panel-button.clock-display:hover > StBoxLayout > StIcon, #panel .panel-button.clock-display:active > StBoxLayout > StIcon {
+  color: #FF4081;
+}
+
 #panel .panel-status-indicators-box,
 #panel .panel-status-menu-box {
   spacing: 2px;

--- a/src/gnome-shell/3.26/message-indicator-symbolic.svg
+++ b/src/gnome-shell/3.26/message-indicator-symbolic.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-  <circle cx="8" cy="8" r="4"/>
+  <circle cx="8" cy="8" r="4" fill="#FF4081" />
 </svg>

--- a/src/gnome-shell/3.26/sass/_common.scss
+++ b/src/gnome-shell/3.26/sass/_common.scss
@@ -891,6 +891,17 @@ StScrollBar {
       color: $inverse_secondary_fg_color;
       &:focus, &:hover, &:active { color: $inverse_fg_color; }
     }
+
+    &.clock-display {
+      > StBoxLayout > StIcon {
+        color: rgba($accent_color, 0.7);
+      }
+
+      &:hover,
+      &:active {
+        > StBoxLayout > StIcon { color: $accent_color; }
+      }
+    }
   }
 
   .panel-status-indicators-box,


### PR DESCRIPTION
`message-indicator-symbolic.svg` doesn't have `fill` set at the moment, so that the notification dot icon next to the clock in gnome-shell appears black, which isn't very visible. The first commit changes the colour to match the `$accent_color` in `_color.scss`.

In addition, if the icon theme provides `message-indicator-symbolic.svg`, the styling of the icon theme overrides the gnome-shell theme (see [this thread](https://github.com/numixproject/numix-icon-theme/issues/1248#issuecomment-336706884) for more information). The second commit works around that.