### PR TITLE
Remove errant "overview" styling

### DIFF
--- a/src/gnome-shell/3.26/sass/_common.scss
+++ b/src/gnome-shell/3.26/sass/_common.scss
@@ -815,7 +815,7 @@ StScrollBar {
   font-weight: bold;
   height: $menuitem_size;
 
-  &:overview,
+  //&:overview,
   &.unlock-screen,
   &.login-screen,
   &.lock-screen {


### PR DESCRIPTION
Having this selector causes the windows not to animate into the Activities overview. It should be removed. See pop-os/gtk-theme#93