### PR TITLE
update Arch installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ Various **desktop environments** are supported:
 Package is available via [AUR](https://aur.archlinux.org/packages/materia-theme/) (maintained by @cthbleachbit):
 
 ```
-yaourt -S materia-theme
+git clone https://aur.archlinux.org/materia-theme.git
+cd materia-theme
+makepkg -si
 ```
 
 #### Fedora / EPEL


### PR DESCRIPTION
## Info

* Materia version: any
* GTK+ 3 version: any
* Distribution: Arch Linux, any version
* Desktop environment: any
* Related application: `yaourt`, `makepkg`. None using GTK itself
* Steps to reproduce: none
* Screenshot(s): none

## Rationale

AUR helpers are [not supported](https://wiki.archlinux.org/index.php/AUR_helpers).
In addition, `yaourt` is [not actively maintained](https://wiki.archlinux.org/index.php/AUR_helpers#Inactive) nor is it recommended to use due to it's insecure and unreliable nature.

## Changes

This PR updates the Arch Linux installation instructions as per [the AUR installation instructions](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages). 
