### PR TITLE
Improving change_color.sh and _color.scss.template for darker themes

### DIFF
--- a/change_color.sh
+++ b/change_color.sh
@@ -9,6 +9,15 @@ darker () {
 mix () {
 	"${SRC_PATH}/scripts/mix.sh" $@
 }
+is_dark() {
+	hexinput=$(echo $1 | tr '[:lower:]' '[:upper:]')
+	half_darker="$(darker ${hexinput} 88)"
+	if [[ "${half_darker}" = "000000" ]] ; then
+		true
+	else
+		return
+	fi
+}
 
 
 print_usage() {
@@ -105,7 +114,7 @@ WM_BORDER_FOCUS=${WM_BORDER_FOCUS-$SEL_BG}
 WM_BORDER_UNFOCUS=${WM_BORDER_UNFOCUS-$MENU_BG}
 
 MATERIA_STYLE_COMPACT=$(echo ${MATERIA_STYLE_COMPACT-True} | tr '[:upper:]' '[:lower:]')
-MATERIA_COLOR_VARIANT=$(echo ${MATERIA_COLOR_VARIANT-light} | tr '[:upper:]' '[:lower:]')
+MATERIA_COLOR_VARIANT=$(echo ${MATERIA_COLOR_VARIANT:-} | tr '[:upper:]' '[:lower:]')
 UNITY_DEFAULT_LAUNCHER_STYLE=$(echo ${UNITY_DEFAULT_LAUNCHER_STYLE-False} | tr '[:upper:]' '[:lower:]')
 
 SPACING=${SPACING-3}
@@ -144,6 +153,18 @@ function post_clean_up {
 trap post_clean_up EXIT SIGHUP SIGINT SIGTERM
 cp -r ${SRC_PATH}/* ${tempdir}/
 cd ${tempdir}
+
+
+# autodetection which color variant to use
+if [[ -z "${MATERIA_COLOR_VARIANT}" ]] ; then
+        if is_dark ${BG} ; then
+            echo "== Dark background color detected. Setting color variant to dark."
+            MATERIA_COLOR_VARIANT="dark"
+        else
+            echo "== Light background color detected. Setting color variant to light."
+            MATERIA_COLOR_VARIANT="light"
+        fi
+fi
 
 
 echo "== Converting theme into template..."

--- a/change_color.sh
+++ b/change_color.sh
@@ -105,8 +105,7 @@ WM_BORDER_FOCUS=${WM_BORDER_FOCUS-$SEL_BG}
 WM_BORDER_UNFOCUS=${WM_BORDER_UNFOCUS-$MENU_BG}
 
 MATERIA_STYLE_COMPACT=$(echo ${MATERIA_STYLE_COMPACT-True} | tr '[:upper:]' '[:lower:]')
-MATERIA_MENUBAR_STYLE=$(echo ${MATERIA_MENUBAR_STYLE-same} | tr '[:upper:]' '[:lower:]')
-GTK3_GENERATE_DARK=$(echo ${GTK3_GENERATE_DARK-True} | tr '[:upper:]' '[:lower:]')
+MATERIA_COLOR_VARIANT=$(echo ${MATERIA_COLOR_VARIANT-light} | tr '[:upper:]' '[:lower:]')
 UNITY_DEFAULT_LAUNCHER_STYLE=$(echo ${UNITY_DEFAULT_LAUNCHER_STYLE-False} | tr '[:upper:]' '[:lower:]')
 
 SPACING=${SPACING-3}
@@ -150,6 +149,7 @@ cd ${tempdir}
 echo "== Converting theme into template..."
 
 for FILEPATH in "${PATHLIST[@]}"; do
+    if [[ ${MATERIA_COLOR_VARIANT}  != "dark" ]] ; then
 	find "${FILEPATH}" -type f -not -name '_color-palette.scss' -exec sed -i'' \
 		-e 's/#000000/%FG%/g' \
 		-e 's/#212121/%FG%/g' \
@@ -166,6 +166,25 @@ for FILEPATH in "${PATHLIST[@]}"; do
 		-e 's/#303030/%MENU_BG3%/g' \
 		-e 's/Materia/%OUTPUT_THEME_NAME%/g' \
 		{} \; ;
+    else
+	find "${FILEPATH}" -type f -not -name '_color-palette.scss' -exec sed -i'' \
+		-e 's/#000000/%BG%/g' \
+		-e 's/#212121/%BG%/g' \
+		-e 's/#757575/%INACTIVE_FG%/g' \
+		-e 's/#BDBDBD/%INACTIVE_FG%/g' \
+		-e 's/#EEEEEE/%FG%/g' \
+		-e 's/#FAFAFA/%BTN_FG%/g' \
+		-e 's/#009688/%ACCENT_BG%/g' \
+		-e 's/#338DD6/%SEL_BG%/g' \
+		-e 's/#FFFFFF/%TXT_FG%/g' \
+		-e 's/#303030/%TXT_BG%/g' \
+		-e 's/#E0E0E0/%MENU_BG%/g' \
+		-e 's/#212121/%MENU_BG2%/g' \
+		-e 's/#303030/%MENU_BG3%/g' \
+		-e 's/Materia/%OUTPUT_THEME_NAME%/g' \
+		{} \; ;
+
+    fi
 done
 
 #Not implemented yet:
@@ -226,16 +245,23 @@ for FILEPATH in "${PATHLIST[@]}"; do
 done
 
 rm ./src/gtk/3.{18,20,22}/*.css
-if [[ ${MATERIA_MENUBAR_STYLE}  == "contrast" ]] ; then
+if [[ ${MATERIA_COLOR_VARIANT}  == "standard" ]] ; then
 	rm ./src/gtk/3.{18,20,22}/gtk-light*.scss
-else
-	rm ./src/gtk/3.{18,20,22}/gtk{,-compact}.scss || true
+	rm ./src/gtk/3.{18,20,22}/gtk-dark*.scss
+	COLOR_VARIANTS=","
+	COLOR_VARIANT="standard"
 fi
-if [[ ${GTK3_GENERATE_DARK} != "true" ]] ; then
-	grep -v "\-dark" ./src/gtk/assets.txt > ./new_assets.txt
-	mv ./new_assets.txt ./src/gtk/assets.txt
-	rm ./src/gtk/3.{20,22}/gtk-dark-compact.scss
-	rm ./src/gtk/3.{18,20,22}/gtk-dark.scss
+if [[ ${MATERIA_COLOR_VARIANT}  == "light" ]] ; then
+	rm ./src/gtk/3.{18,20,22}/gtk-dark*.scss 
+	rm ./src/gtk/3.{18,20,22}/gtk{,-compact}.scss || true
+	COLOR_VARIANTS="-light"
+	COLOR_VARIANT="light"
+fi
+if [[ ${MATERIA_COLOR_VARIANT}  == "dark" ]] ; then
+	rm ./src/gtk/3.{18,20,22}/gtk-light*.scss
+	rm ./src/gtk/3.{18,20,22}/gtk{,-compact}.scss || true
+	COLOR_VARIANTS="-dark"
+	COLOR_VARIANT="dark"
 fi
 if [[ ${OPTION_GTK2_HIDPI} == "true" ]] ; then
 	mv ./src/gtk-2.0/main.rc.hidpi ./src/gtk-2.0/main.rc
@@ -260,29 +286,19 @@ else
 	SIZE_VARIANTS=","
 	SIZE_VARIANT="standard"
 fi
-if [[ ${MATERIA_MENUBAR_STYLE}  == "contrast" ]] ; then
-	COLOR_VARIANTS=","
-	COLOR_VARIANT="standard"
-else
-	COLOR_VARIANTS="-light"
-	COLOR_VARIANT="light"
-fi
 
 SIZE_VARIANTS="${SIZE_VARIANTS}" COLOR_VARIANTS="${COLOR_VARIANTS}" THEME_DIR_BASE=${DEST_PATH} ./parse-sass.sh
 
-rm ./src/gtk-2.0/assets/*.png || true
-rm ./src/gtk-2.0/assets-dark/*.png || true
-rm ./src/gtk/assets/*.png || true
-
+# NOTE we use the functions we already have in render-assets.sh
 echo "== Rendering GTK+2 assets..."
-cd ./src/gtk-2.0
-GTK2_HIDPI=${OPTION_GTK2_HIDPI} ./render-assets.sh
-cd ../../
+if [[ ${MATERIA_COLOR_VARIANT}  != "dark" ]] ; then
+        GTK2_HIDPI=${OPTION_GTK2_HIDPI} ./render-assets.sh gtk2-light
+else
+        GTK2_HIDPI=${OPTION_GTK2_HIDPI} ./render-assets.sh gtk2-dark
+fi
 
 echo "== Rendering GTK+3 assets..."
-cd ./src/gtk
-./render-assets.sh
-cd ../../
+./render-assets.sh gtk
 
 ./install.sh --dest "$HOME/.themes" --name "${OUTPUT_THEME_NAME/\//-}" --color "${COLOR_VARIANT}" --size "${SIZE_VARIANT}"
 

--- a/change_color.sh
+++ b/change_color.sh
@@ -195,6 +195,7 @@ for FILEPATH in "${PATHLIST[@]}"; do
 		-e 's/#BDBDBD/%INACTIVE_FG%/g' \
 		-e 's/#EEEEEE/%FG%/g' \
 		-e 's/#FAFAFA/%BTN_FG%/g' \
+		-e 's/#424242/%BTN_BG%/g' \
 		-e 's/#009688/%ACCENT_BG%/g' \
 		-e 's/#338DD6/%SEL_BG%/g' \
 		-e 's/#FFFFFF/%TXT_FG%/g' \

--- a/change_color.sh
+++ b/change_color.sh
@@ -176,6 +176,7 @@ for FILEPATH in "${PATHLIST[@]}"; do
 		-e 's/#212121/%FG%/g' \
 		-e 's/#757575/%INACTIVE_FG%/g' \
 		-e 's/#BDBDBD/%INACTIVE_FG%/g' \
+		-e 's/#F5F5F5/%INACTIVE_TXT_BG%/g' \
 		-e 's/#EEEEEE/%BG%/g' \
 		-e 's/#FAFAFA/%BTN_BG%/g' \
 		-e 's/#009688/%ACCENT_BG%/g' \
@@ -184,7 +185,6 @@ for FILEPATH in "${PATHLIST[@]}"; do
 		-e 's/#303030/%MENU_BG%/g' \
 		-e 's/#E0E0E0/%MENU_BG%/g' \
 		-e 's/#212121/%MENU_BG2%/g' \
-		-e 's/#303030/%MENU_BG3%/g' \
 		-e 's/Materia/%OUTPUT_THEME_NAME%/g' \
 		{} \; ;
     else
@@ -193,6 +193,7 @@ for FILEPATH in "${PATHLIST[@]}"; do
 		-e 's/#212121/%BG%/g' \
 		-e 's/#757575/%INACTIVE_FG%/g' \
 		-e 's/#BDBDBD/%INACTIVE_FG%/g' \
+		-e 's/#292929/%INACTIVE_TXT_BG%/g' \
 		-e 's/#EEEEEE/%FG%/g' \
 		-e 's/#FAFAFA/%BTN_FG%/g' \
 		-e 's/#424242/%BTN_BG%/g' \
@@ -202,7 +203,6 @@ for FILEPATH in "${PATHLIST[@]}"; do
 		-e 's/#303030/%TXT_BG%/g' \
 		-e 's/#E0E0E0/%MENU_BG%/g' \
 		-e 's/#212121/%MENU_BG2%/g' \
-		-e 's/#303030/%MENU_BG3%/g' \
 		-e 's/Materia/%OUTPUT_THEME_NAME%/g' \
 		{} \; ;
 

--- a/src/_sass/_colors.scss.template
+++ b/src/_sass/_colors.scss.template
@@ -41,23 +41,23 @@ $inverse_track_color:                 rgba(%SEL_FG%, 0.3);
 $inverse_divider_color:               rgba(%SEL_FG%, 0.12);
 
 // Background colors
-$bg_color:             if($variant == 'light', %BG%, fade(%MENU_BG%));
-$base_color:           if($variant == 'light', %TXT_BG%,    fade(%MENU_BG%));
-$alt_base_color:       if($variant == 'light', %INACTIVE_TXT_BG%,  mix(%INACTIVE_TXT_BG%, %MENU_BG%, 50%));
-$lighter_bg_color:     if($variant == 'light', %BTN_BG%,  fade(%BTN_BG%));
-$alt_lighter_bg_color: if($variant == 'light', %BG2%, fade(%MENU_BG%)); // for gnome-shell sub menu
-$darker_bg_color:      if($variant == 'light', %BG%, fade(%MENU_BG%));
+$bg_color:             %BG%;
+$base_color:           %TXT_BG%;
+$alt_base_color:       %INACTIVE_TXT_BG%;
+$lighter_bg_color:     %BTN_BG%;
+$alt_lighter_bg_color: if($variant == 'light', %BG2%, %MENU_BG%); // for gnome-shell sub menu
+$darker_bg_color:      if($variant == 'light', %BG%, %MENU_BG%);
 
 $titlebar_bg_color: %MENU_BG%;
-$alt_titlebar_bg_color: if($titlebar == 'dark', %MENU_BG%, %MENU_BG%);
+$alt_titlebar_bg_color: %MENU_BG%;
 
 $panel_bg_color:         rgba(%MENU_BG%, %GNOME_SHELL_PANEL_OPACITY%);
 $alt_panel_bg_color:     rgba(%MENU_BG%, $lower_opacity);
 $inverse_panel_bg_color: rgba($inverse_fg_color, 0.1);
-$solid_panel_bg_color:   if($titlebar == 'dark', %MENU_BG%, %MENU_BG%);
+$solid_panel_bg_color:   %MENU_BG%;
 $opaque_panel_bg_color:  if($titlebar == 'dark', %MENU_BG%, mix(%MENU_BG%, %MENU_BG%, 50%)); // for Unity panel which cannot use translucent colors
 
-$gdm_bg_color: if($variant == 'light', %MENU_BG%, %MENU_BG2%);
+$gdm_bg_color: %MENU_BG%;
 
 $fill_color:      gtkalpha(currentColor, $lower_opacity);
 $semi_fill_color: gtkalpha(currentColor, $lower_opacity / 2);
@@ -87,11 +87,11 @@ $error_bg_color: $error_color;
 $tooltip_bg_color: %MENU_BG%;
 $tooltip_fg_color: %MENU_FG%;
 
-$border_color:             if($variant == 'light', rgba(%FG%, 0.12), rgba(%FG%, 0.26));
+$border_color:             if($variant == 'light', rgba(%FG%, 0.12), rgba(%MENU_BG%, 0.26));
 $alt_border_color:         rgba(%FG%, 0.26); // for non-native GTK+ apps (e.g. Firefox and Chrome)
-$highlight_color:          if($variant == 'light', rgba(%TXT_BG%, 0.4),  rgba(%TXT_BG%, 0.1));
-$titlebar_highlight_color: %MENU_BG%;
-$alt_highlight_color:      rgba(%TXT_BG%, 0.2); // for selection-mode headerbar which colored with $primary_color
+$highlight_color:          if($variant == 'light', rgba(%TXT_BG%, 0.4),  rgba(%TXT_FG%, 0.1));
+$titlebar_highlight_color: if($titlebar == 'dark', rgba(%MENU_BG%, 0.1),  rgba(%MENU_FG%, 0.4));
+$alt_highlight_color:      if($variant == 'light', rgba(%TXT_BG%, 0.2), rgba(%TXT_FG%, 0.2)); // for selection-mode headerbar which colored with $primary_color
 $titlebar_indicator_color: if($titlebar == 'dark', currentColor, $primary_color);
 
 // for Electron/Atom menu which cannot use translucent colors

--- a/src/_sass/_colors.scss.template
+++ b/src/_sass/_colors.scss.template
@@ -95,10 +95,10 @@ $alt_highlight_color:      if($variant == 'light', rgba(%TXT_BG%, 0.2), rgba(%TX
 $titlebar_indicator_color: if($titlebar == 'dark', currentColor, $primary_color);
 
 // for Electron/Atom menu which cannot use translucent colors
-$opaque_fg_color:           if($variant == 'light', %FG%, %TXT_BG%);
-$opaque_secondary_fg_color: if($variant == 'light', %FG%, mix(%TXT_BG%, $base_color, percentage(0.7)));
-$opaque_disabled_fg_color:  if($variant == 'light', %INACTIVE_FG%, mix(%TXT_BG%, $base_color, percentage(0.5)));
-$opaque_divider_color:      if($variant == 'light', %SEL_BG%, mix(%TXT_BG%, $base_color, percentage(0.12)));
+$opaque_fg_color:           %FG%;
+$opaque_secondary_fg_color: mix(%FG%, $base_color, percentage(0.7));
+$opaque_disabled_fg_color:  mix(%FG%, $base_color, percentage(0.5));
+$opaque_divider_color:      mix(%FG%, $base_color, percentage(0.12));
 
 // FIXME: gtk's @placeholder_text_color API really should use $secondary_fg_color,
 // but it doesn't work with translucent colors. So we use opaque colors instead.


### PR DESCRIPTION
Hey here is my little attempt to improve coloring of dark materia themes.
@actionless would be nice if you could review this. Dark themes look now better in my opinion if the new value is set to dark. IMPORTANT Until we implement `is_dark`nothing should change on the user side if the new variable is not set or set to light/standard.

### change_color.sh
* Created new value MATERIA_COLOR_VARIANT which should be light/dark/standard, default is set to light, so that nothing changes for oomox users or if the value is not set.
* Created new seds for recoloring gtkrc-dark only used if MATERIA_COLOR_VARIANT=dark
* Removed GTK3_GENERATE_DARK (experimental, could leave a placeholder)
* Removed MATERIA_MENUBAR_STYLE (experimental, could leave a placeholder)
* Adapted the if clauses for every case light/dark/standard
* Removed navigating in sourcetree, removing asset pngs and manual render-assets.sh's because the render-assets.sh at project root provides all that 
* if MATERIA_COLOR_VARIANT=dark not set render only the light assets and the other way around
* Implemented autodetection for dark/light backgrounds on what color variant to use if the value is not set

### _colors.scss.template
* provided dark colors for the dark color variant like in materia's _colors.scss whereever necessary and removed/simplified rendundant statements where the result is the same no matter if MATERIA_COLOR_VARIANT set to dark or light
* MENU_BG2 is nice for light themes because of darken, but way too dark (almost black) for dark themes, so I choose MENU_BG for now which should be a different shade than TXT_BG/BTN_BG and looks consistent
* I tried to not touch the light colors, so pls check if that's true and everything (coloring if MATERIA_COLOR_VARIANT is not set or set to light/standard) will work as before after this pr

### What has changed now for dark themes?
* when MATERIA_COLOR_VARIANT is set to dark now, we can make use of materia's rgba()'s and a few issues like too bright border colors are solved:
* There were a few cases in gnome-shell with dark fg on dark bg like the gnome-workspaces extention. Fixed now.
* in gtk2 there was a bug with dark themes where item previews were unreadable due to dark fg, dark bg. Fixed now
 * dark gtk2 themes have now a fg color as selection fg like the light theme variant and materia itself which makes it more consistent
* Border colors are intentionally very dark now (like the dark materia theme) and could be changed to BG, TXT_BG or BTN_BG. I personally like it like this the most but tastes differ as we know.

Here is a little [example](https://ptpb.pw/QH85) of a dark materia theme with the nord color palette.