### PR TITLE
Cinnamon4 update

### DIFF
--- a/src/_sass/cinnamon/_common.scss
+++ b/src/_sass/cinnamon/_common.scss
@@ -98,7 +98,7 @@ StScrollView {
 	spacing: 0.4em;
 	transition-duration: $shorter_duration;
   &:active {
-    background-color: $track_color;
+    background-color: $titlebar_track_color;
     color: $fg_color;
     transition-duration: $longer_duration;
   }
@@ -235,6 +235,24 @@ StScrollView {
       }
     }
   }
+  .grouped-window-list-item-box {
+    &:hover {
+      box-shadow: 0 3px 0 0 $secondary_color inset;
+    }
+    &:active, &:checked {
+      background-color: $titlebar_divider_color;
+      &:hover {
+        box-shadow: 0 3px 0 0 $secondary_color inset;
+      }
+    }
+    &:focus {
+      background-color: $titlebar_track_color;
+      color: $titlebar_fg_color;
+      &:hover {
+        box-shadow: 0 3px 0 0 $secondary_color inset;
+      }
+    }
+  }
   .workspace-switcher, .workspace-graph, .workspace-button {
     padding: 1px 4px;
   }
@@ -244,8 +262,7 @@ StScrollView {
     }
   }
   .applet-box {
-    padding: 1px 4px;
-    margin: 1px 0;
+    padding: 0 4px;
     &:hover {
       box-shadow: 0 3px 0 0 $secondary_color inset;
     }
@@ -275,6 +292,24 @@ StScrollView {
       }
     }
   }
+  .grouped-window-list-item-box {
+    &:hover {
+      box-shadow: 0 -3px 0 0 $secondary_color inset;
+    }
+    &:active, &:checked {
+      background-color: $titlebar_divider_color;
+      &:hover {
+        box-shadow: 0 -3px 0 0 $secondary_color inset;
+      }
+    }
+    &:focus {
+      background-color: $titlebar_track_color;
+      color: $titlebar_fg_color;
+      &:hover {
+        box-shadow: 0 -3px 0 0 $secondary_color inset;
+      }
+    }
+  }
   .workspace-switcher, .workspace-graph, .workspace-button {
     padding: 1px 4px;
   }
@@ -284,8 +319,7 @@ StScrollView {
     }
   }
   .applet-box {
-    padding: 1px 4px;
-    margin: 1px 0;
+    padding: 0 4px;
     &:hover {
       box-shadow: 0 -3px 0 0 $secondary_color inset;
     }
@@ -315,6 +349,24 @@ StScrollView {
       }
     }
   }
+  .grouped-window-list-item-box {
+    &:hover {
+      box-shadow: 3px 0 0 0 $secondary_color inset;
+    }
+    &:active, &:checked {
+      background-color: $titlebar_divider_color;
+      &:hover {
+        box-shadow: 3px 0 0 0 $secondary_color inset;
+      }
+    }
+    &:focus {
+      background-color: $titlebar_track_color;
+      color: $titlebar_fg_color;
+      &:hover {
+        box-shadow: 3px 0 0 0 $secondary_color inset;
+      }
+    }
+  }
   .workspace-switcher, .workspace-graph, .workspace-button {
     padding: 4px 1px;
     min-height: 1.2em;
@@ -325,8 +377,7 @@ StScrollView {
     }
   }
   .applet-box {
-    padding: 4px 1px;
-    margin: 0 1px;
+    padding: 4px 0;
     &:hover {
       box-shadow: 3px 0 0 0 $secondary_color inset;
     }
@@ -356,6 +407,24 @@ StScrollView {
       }
     }
   }
+  .grouped-window-list-item-box {
+    &:hover {
+      box-shadow: -3px 0 0 0 $secondary_color inset;
+    }
+    &:active, &:checked {
+      background-color: $titlebar_divider_color;
+      &:hover {
+        box-shadow: -3px 0 0 0 $secondary_color inset;
+      }
+    }
+    &:focus {
+      background-color: $titlebar_track_color;
+      color: $titlebar_fg_color;
+      &:hover {
+        box-shadow: -3px 0 0 0 $secondary_color inset;
+      }
+    }
+  }
   .workspace-switcher, .workspace-graph, .workspace-button {
     padding: 4px 1px;
     min-height: 1.2em;
@@ -366,8 +435,7 @@ StScrollView {
     }
   }
   .applet-box {
-    padding: 4px 1px;
-    margin: 0 1px;
+    padding: 4px 0;
     &:hover {
       box-shadow: -3px 0 0 0 $secondary_color inset;
     }
@@ -560,7 +628,7 @@ StScrollView {
   padding: 0;
   margin: 2px;
   border-radius: 100px;
-  &:hover,&:focus { background-color: $track_color; }
+  &:hover,&:focus { background-color: $titlebar_track_color; }
   &:active {
     color: $inverse_fg_color;
     background-color: $secondary_color;
@@ -1045,6 +1113,77 @@ StScrollView {
   padding: 10px 15px;
   spacing: 1em;
   color: $fg_color;
+}
+// Cinnamon 4.0 has a new grouped window list applet with it's own selectors.
+// Initial theme support is defined here.
+.grouped-window-list-thumbnail-label {
+  padding-left: 3px;
+  padding-bottom: 6px;
+}
+.grouped-window-list-number-label {
+  @include font(caption);
+  z-index: 99;
+}
+.grouped-window-list-button-label {
+  padding-left: 3px;
+}
+.grouped-window-list-badge {
+  border-radius: $circular_radius;
+  background-color: $solid_panel_bg_color; 
+}
+.panel-top .grouped-window-list-badge {
+  margin-top: 2px;
+}
+.panel-left .grouped-window-list-badge {
+  margin-left: 2px;
+}
+.grouped-window-list-thumbnail-alert {
+  background: $warning_color;
+}
+.grouped-window-list-item-box {
+  background-color: rgba(0, 0, 0, 0.01);
+  transition-duration: $shorter_duration;
+  &:hover {
+    color: $titlebar_fg_color;
+  }
+  &:highlight {
+  }
+  .progress {
+    background-color: $success_color;
+  }
+}
+.grouped-window-list-item-box StIcon {
+}
+.grouped-window-list-item-box StBin {
+}
+.grouped-window-list-item-demands-attention {
+  background-color: $info_bg_color;
+  color: $titlebar_secondary_fg_color;
+}
+.grouped-window-list-thumbnail-menu {
+  border-radius: $material_radius;
+  padding: 10px 15px;
+  spacing: 1em;
+  color: $fg_color;
+}
+.grouped-window-list-thumbnail-menu .item-box {
+    padding: 4px 8px;
+}
+.grouped-window-list-thumbnail-menu .item-box:outlined {
+  background: $titlebar_divider_color;
+}
+.grouped-window-list-thumbnail-menu .item-box:selected {
+  background: $titlebar_track_color;
+}
+.grouped-window-list-thumbnail-menu .thumbnail-box {
+  spacing: 4px;
+}
+.grouped-window-list-thumbnail-menu .thumbnail {
+  width: 256px;
+}
+.grouped-window-list-thumbnail-menu .separator {
+  width: 1px;
+  background: $border_color;
 }
 // the sound player applet
 .sound-player {

--- a/src/_sass/cinnamon/_common.scss
+++ b/src/_sass/cinnamon/_common.scss
@@ -88,6 +88,7 @@ StScrollView {
 // individual menu entries are themed here
 .popup-menu-item {
 	padding: 0.4em 4px;
+	spacing: 0.4em;
 	transition-duration: $shorter_duration;
   &:active {
     background-color: $track_color;
@@ -121,7 +122,6 @@ StScrollView {
 }
 .popup-menu-icon {
   icon-size: 1.14em;
-  padding: 0px 4px;
 }
 .popup-menu-item-dot {
 }

--- a/src/_sass/cinnamon/_common.scss
+++ b/src/_sass/cinnamon/_common.scss
@@ -1102,6 +1102,9 @@ StScrollView {
     background-color: $success_color;
   }
 }
+.window-list-item-box.top StLabel, .window-list-item-box.bottom StLabel {
+  padding-left: 3px;
+}
 .window-list-item-demands-attention {
   background-color: $info_bg_color;
   color: $titlebar_secondary_fg_color;

--- a/src/_sass/cinnamon/_common.scss
+++ b/src/_sass/cinnamon/_common.scss
@@ -410,6 +410,10 @@ StScrollView {
 #overview {
   spacing: 12px;
 }
+.overview-empty-placeholder {
+    @extend %osd-info-workspace-shared;
+    
+}
 .window-caption {
   @include font(caption);
 
@@ -419,7 +423,7 @@ StScrollView {
   text-align: center;
   height: 1.5em;
   -cinnamon-caption-spacing: 12px;
-  &#selected {
+  &#selected, &:focus {
     color: $titlebar_fg_color;
     box-shadow: 0 -3px 0 0 $secondary_color inset;
   }
@@ -458,6 +462,9 @@ StScrollView {
   &:rtl {
     -st-background-image-shadow: 2px 2px 6px rgba(0,0,0,0.5);
   }
+}
+.window-border {
+    border: 1px solid $border_color;
 }
 .window-close-area {
   background-image: url(assets/trash-icon.png);

--- a/src/_sass/cinnamon/_common.scss
+++ b/src/_sass/cinnamon/_common.scss
@@ -309,7 +309,8 @@ StScrollView {
     }
   }
   .workspace-switcher, .workspace-graph, .workspace-button {
-    padding: 1px 4px;
+    padding: 4px 1px;
+    min-height: 1.2em;
   }
   .workspace-graph, .workspace-button {;
     &:hover {
@@ -349,7 +350,8 @@ StScrollView {
     }
   }
   .workspace-switcher, .workspace-graph, .workspace-button {
-    padding: 1px 4px;
+    padding: 4px 1px;
+    min-height: 1.2em;
   }
   .workspace-graph, .workspace-button {;
     &:hover {

--- a/src/_sass/cinnamon/_common.scss
+++ b/src/_sass/cinnamon/_common.scss
@@ -70,6 +70,13 @@ StScrollView {
   min-width: 100px;
   margin: 4px;
 }
+// new style-classes for alternative stock menu
+.menu-top-box {
+  spacing: 5px;
+}
+.menu-systembuttons-box {
+  padding: 10px;
+}
 .popup-sub-menu {
   background-color: $alt_lighter_bg_color;
 }

--- a/src/_sass/cinnamon/_common.scss
+++ b/src/_sass/cinnamon/_common.scss
@@ -228,8 +228,6 @@ StScrollView {
       box-shadow: 0 3px 0 0 $secondary_color inset;
     }
     &:active, &:checked, &:focus {
-      background-color: $titlebar_track_color;
-      color: $titlebar_fg_color;
       &:hover {
         box-shadow: 0 3px 0 0 $secondary_color inset;
       }
@@ -240,18 +238,18 @@ StScrollView {
       box-shadow: 0 3px 0 0 $secondary_color inset;
     }
     &:active, &:checked {
-      background-color: $titlebar_divider_color;
       &:hover {
         box-shadow: 0 3px 0 0 $secondary_color inset;
       }
     }
     &:focus {
-      background-color: $titlebar_track_color;
-      color: $titlebar_fg_color;
       &:hover {
         box-shadow: 0 3px 0 0 $secondary_color inset;
       }
     }
+  }
+  .grouped-window-list-badge {
+    margin-top: 2px;
   }
   .workspace-switcher, .workspace-graph, .workspace-button {
     padding: 1px 4px;
@@ -285,8 +283,6 @@ StScrollView {
       box-shadow: 0 -3px 0 0 $secondary_color inset;
     }
     &:active, &:checked, &:focus {
-      background-color: $titlebar_track_color;
-      color: $titlebar_fg_color;
       &:hover {
         box-shadow: 0 -3px 0 0 $secondary_color inset;
       }
@@ -297,14 +293,11 @@ StScrollView {
       box-shadow: 0 -3px 0 0 $secondary_color inset;
     }
     &:active, &:checked {
-      background-color: $titlebar_divider_color;
       &:hover {
         box-shadow: 0 -3px 0 0 $secondary_color inset;
       }
     }
     &:focus {
-      background-color: $titlebar_track_color;
-      color: $titlebar_fg_color;
       &:hover {
         box-shadow: 0 -3px 0 0 $secondary_color inset;
       }
@@ -342,8 +335,6 @@ StScrollView {
       box-shadow: 3px 0 0 0 $secondary_color inset;
     }
     &:active, &:checked, &:focus {
-      background-color: $titlebar_track_color;
-      color: $titlebar_fg_color;
       &:hover {
         box-shadow: 3px 0 0 0 $secondary_color inset;
       }
@@ -354,18 +345,18 @@ StScrollView {
       box-shadow: 3px 0 0 0 $secondary_color inset;
     }
     &:active, &:checked {
-      background-color: $titlebar_divider_color;
       &:hover {
         box-shadow: 3px 0 0 0 $secondary_color inset;
       }
     }
     &:focus {
-      background-color: $titlebar_track_color;
-      color: $titlebar_fg_color;
       &:hover {
         box-shadow: 3px 0 0 0 $secondary_color inset;
       }
     }
+  }
+  .grouped-window-list-badge {
+    margin-left: 2px;
   }
   .workspace-switcher, .workspace-graph, .workspace-button {
     padding: 4px 1px;
@@ -400,8 +391,6 @@ StScrollView {
       box-shadow: -3px 0 0 0 $secondary_color inset;
     }
     &:active, &:checked, &:focus {
-      background-color: $titlebar_track_color;
-      color: $titlebar_fg_color;
       &:hover {
         box-shadow: -3px 0 0 0 $secondary_color inset;
       }
@@ -412,14 +401,11 @@ StScrollView {
       box-shadow: -3px 0 0 0 $secondary_color inset;
     }
     &:active, &:checked {
-      background-color: $titlebar_divider_color;
       &:hover {
         box-shadow: -3px 0 0 0 $secondary_color inset;
       }
     }
     &:focus {
-      background-color: $titlebar_track_color;
-      color: $titlebar_fg_color;
       &:hover {
         box-shadow: -3px 0 0 0 $secondary_color inset;
       }
@@ -1096,7 +1082,12 @@ StScrollView {
   &:hover {
     color: $titlebar_fg_color;
   }
-  &:highlight {
+  &:active, &:checked, &:focus {
+    background-color: $titlebar_track_color;
+    color: $titlebar_fg_color;
+    &:hover {
+      color: $titlebar_fg_color;
+    }
   }
   .progress {
     background-color: $success_color;
@@ -1116,77 +1107,98 @@ StScrollView {
   padding: 10px 15px;
   spacing: 1em;
   color: $fg_color;
+  box-shadow: $shadow_6;
 }
 // Cinnamon 4.0 has a new grouped window list applet with it's own selectors.
-// Initial theme support is defined here.
-.grouped-window-list-thumbnail-label {
-  padding-left: 3px;
-  padding-bottom: 6px;
-}
-.grouped-window-list-number-label {
-  @include font(caption);
-  z-index: 99;
-}
-.grouped-window-list-button-label {
-  padding-left: 3px;
-}
-.grouped-window-list-badge {
-  border-radius: $circular_radius;
-  background-color: $solid_panel_bg_color; 
-}
-.panel-top .grouped-window-list-badge {
-  margin-top: 2px;
-}
-.panel-left .grouped-window-list-badge {
-  margin-left: 2px;
-}
-.grouped-window-list-thumbnail-alert {
-  background: $warning_color;
-}
-.grouped-window-list-item-box {
-  background-color: rgba(0, 0, 0, 0.01);
-  transition-duration: $shorter_duration;
-  &:hover {
-    color: $titlebar_fg_color;
+// Initial theme support is defined here. Some theming is defined in the panel orientation specific section above.
+.grouped-window-list {
+  &-thumbnail-label {
+    padding-left: 3px;
+    padding-bottom: 6px;
   }
-  &:highlight {
+  &-number-label {
+    @include font(caption);
+    
+    z-index: 99;
   }
-  .progress {
-    background-color: $success_color;
+  &-list-button-label {
+    padding-left: 3px;
   }
-}
-.grouped-window-list-item-box StIcon {
-}
-.grouped-window-list-item-box StBin {
-}
-.grouped-window-list-item-demands-attention {
-  background-color: $info_bg_color;
-  color: $titlebar_secondary_fg_color;
-}
-.grouped-window-list-thumbnail-menu {
-  border-radius: $material_radius;
-  padding: 10px 15px;
-  spacing: 1em;
-  color: $fg_color;
-}
-.grouped-window-list-thumbnail-menu .item-box {
-    padding: 4px 8px;
-}
-.grouped-window-list-thumbnail-menu .item-box:outlined {
-  background: $titlebar_divider_color;
-}
-.grouped-window-list-thumbnail-menu .item-box:selected {
-  background: $titlebar_track_color;
-}
-.grouped-window-list-thumbnail-menu .thumbnail-box {
-  spacing: 4px;
-}
-.grouped-window-list-thumbnail-menu .thumbnail {
-  width: 256px;
-}
-.grouped-window-list-thumbnail-menu .separator {
-  width: 1px;
-  background: $border_color;
+  &-badge {
+    border-radius: $circular_radius;
+    background-color: $solid_panel_bg_color; 
+  }
+  &-thumbnail-alert {
+    background: $warning_color;
+  }
+  &-item-box {
+    background-color: rgba(0, 0, 0, 0.01);
+    transition-duration: $shorter_duration;
+    &:hover {
+      color: $titlebar_fg_color;
+    }
+    &:active, &:checked {
+      background-color: $titlebar_divider_color;
+      &:hover {
+        color: $titlebar_fg_color;
+      }
+    }
+    &:focus {
+      background-color: $titlebar_track_color;
+      color: $titlebar_fg_color;
+      &:hover {
+        color: $titlebar_fg_color;
+      }
+    }
+    .progress {
+      background-color: $success_color;
+    }
+  }
+  &-item-demands-attention {
+    background-color: $info_bg_color;
+    color: $titlebar_secondary_fg_color;
+  }
+  &-thumbnail-menu {
+    padding: 20px;
+    border: none;
+    border-radius: $material_radius;
+    color: $titlebar_secondary_fg_color;
+    background: none;
+    .item-box {
+      padding: 8px;
+      spacing: 2px;
+      border-radius: $material_radius;
+       &:outlined {
+         border: 2px solid $border_color;
+         color: $titlebar_fg_color;
+       }
+       &:selected {
+         background: $titlebar_divider_color;
+         color: $titlebar_fg_color;
+       }
+       > StBoxLayout { // icon and title
+        &:ltr { margin: 1px 0 0 6px; }
+        &:rtl { margin: 1px 6px 0 0; }
+
+        StLabel { padding-bottom: 2px; }
+      }
+
+      > StButton { // close button
+        &:ltr { margin: 1px 6px 0 0; }
+        &:rtl { margin: 1px 0 0 6px; }
+      }
+    }
+    .thumbnail-box {
+      padding: 2px;
+    }
+    .thumbnail {
+      width: 256px;
+    }
+    .separator {
+      width: 1px;
+      background: $border_color;
+    }
+  }
 }
 // the sound player applet
 .sound-player {

--- a/src/_sass/cinnamon/_extends.scss
+++ b/src/_sass/cinnamon/_extends.scss
@@ -43,7 +43,7 @@
 %dialog-entry-shared {
   @include entry(normal,$fc:$track_color);
 
-  width: 320px;
+  width: 250px;
   padding: 4px 8px;
   border-radius: 0;
   color: $hint_fg_color;


### PR DESCRIPTION
Closes #310

* Cinnamon - add support for Cinnamon 4 grouped window list
* Cinnamon - add support for new styles used in Cinnamon 4 overview
* Cinnamon - add support for alternative Cinnamon 4 stock menu
* Cinnamon - tweaked use of padding and margins in panel items to avoid icon distortion for user defined panel icon sizes in Cinnamon 4
* Cinnamon - bugfix - fixed workspace-overview in vertical panels
* Cinnamon - bugfix - fixed popup-menu-item spacing/padding for right click context menu's in panel.
* Cinnamon - bugfix - add a little padding between icon + label in the window-list applet