### PR TITLE
Fix oversized keyboard on Gnome

### DIFF
--- a/src/gnome-shell/3.18/gnome-shell-compact.css
+++ b/src/gnome-shell/3.18/gnome-shell-compact.css
@@ -2318,9 +2318,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 64px;
-  min-width: 64px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.18/gnome-shell-dark-compact.css
+++ b/src/gnome-shell/3.18/gnome-shell-dark-compact.css
@@ -2318,9 +2318,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 64px;
-  min-width: 64px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.18/gnome-shell-dark.css
+++ b/src/gnome-shell/3.18/gnome-shell-dark.css
@@ -2318,9 +2318,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 72px;
-  min-width: 72px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.18/gnome-shell-light-compact.css
+++ b/src/gnome-shell/3.18/gnome-shell-light-compact.css
@@ -2318,9 +2318,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 64px;
-  min-width: 64px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.18/gnome-shell-light.css
+++ b/src/gnome-shell/3.18/gnome-shell-light.css
@@ -2318,9 +2318,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 72px;
-  min-width: 72px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.18/gnome-shell.css
+++ b/src/gnome-shell/3.18/gnome-shell.css
@@ -2318,9 +2318,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 72px;
-  min-width: 72px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.24/gnome-shell-compact.css
+++ b/src/gnome-shell/3.24/gnome-shell-compact.css
@@ -2360,9 +2360,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 64px;
-  min-width: 64px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.24/gnome-shell-dark-compact.css
+++ b/src/gnome-shell/3.24/gnome-shell-dark-compact.css
@@ -2360,9 +2360,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 64px;
-  min-width: 64px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.24/gnome-shell-dark.css
+++ b/src/gnome-shell/3.24/gnome-shell-dark.css
@@ -2360,9 +2360,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 72px;
-  min-width: 72px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.24/gnome-shell-light-compact.css
+++ b/src/gnome-shell/3.24/gnome-shell-light-compact.css
@@ -2360,9 +2360,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 64px;
-  min-width: 64px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.24/gnome-shell-light.css
+++ b/src/gnome-shell/3.24/gnome-shell-light.css
@@ -2360,9 +2360,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 72px;
-  min-width: 72px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.24/gnome-shell.css
+++ b/src/gnome-shell/3.24/gnome-shell.css
@@ -2360,9 +2360,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 72px;
-  min-width: 72px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.26/gnome-shell-compact.css
+++ b/src/gnome-shell/3.26/gnome-shell-compact.css
@@ -2339,9 +2339,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 64px;
-  min-width: 64px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.26/gnome-shell-dark-compact.css
+++ b/src/gnome-shell/3.26/gnome-shell-dark-compact.css
@@ -2339,9 +2339,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 64px;
-  min-width: 64px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.26/gnome-shell-dark.css
+++ b/src/gnome-shell/3.26/gnome-shell-dark.css
@@ -2339,9 +2339,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 72px;
-  min-width: 72px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.26/gnome-shell-light-compact.css
+++ b/src/gnome-shell/3.26/gnome-shell-light-compact.css
@@ -2339,9 +2339,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 64px;
-  min-width: 64px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.26/gnome-shell-light.css
+++ b/src/gnome-shell/3.26/gnome-shell-light.css
@@ -2339,9 +2339,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 72px;
-  min-width: 72px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.26/gnome-shell.css
+++ b/src/gnome-shell/3.26/gnome-shell.css
@@ -2339,9 +2339,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 72px;
-  min-width: 72px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.28/gnome-shell-compact.css
+++ b/src/gnome-shell/3.28/gnome-shell-compact.css
@@ -2342,9 +2342,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 64px;
-  min-width: 64px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.28/gnome-shell-dark-compact.css
+++ b/src/gnome-shell/3.28/gnome-shell-dark-compact.css
@@ -2342,9 +2342,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 64px;
-  min-width: 64px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.28/gnome-shell-dark.css
+++ b/src/gnome-shell/3.28/gnome-shell-dark.css
@@ -2342,9 +2342,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 72px;
-  min-width: 72px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.28/gnome-shell-light-compact.css
+++ b/src/gnome-shell/3.28/gnome-shell-light-compact.css
@@ -2342,9 +2342,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 64px;
-  min-width: 64px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.28/gnome-shell-light.css
+++ b/src/gnome-shell/3.28/gnome-shell-light.css
@@ -2342,9 +2342,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 72px;
-  min-width: 72px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.28/gnome-shell.css
+++ b/src/gnome-shell/3.28/gnome-shell.css
@@ -2342,9 +2342,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 72px;
-  min-width: 72px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.30/gnome-shell-compact.css
+++ b/src/gnome-shell/3.30/gnome-shell-compact.css
@@ -2349,9 +2349,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 64px;
-  min-width: 64px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.30/gnome-shell-dark-compact.css
+++ b/src/gnome-shell/3.30/gnome-shell-dark-compact.css
@@ -2349,9 +2349,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 64px;
-  min-width: 64px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.30/gnome-shell-dark.css
+++ b/src/gnome-shell/3.30/gnome-shell-dark.css
@@ -2349,9 +2349,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 72px;
-  min-width: 72px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.30/gnome-shell-light-compact.css
+++ b/src/gnome-shell/3.30/gnome-shell-light-compact.css
@@ -2349,9 +2349,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 64px;
-  min-width: 64px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.30/gnome-shell-light.css
+++ b/src/gnome-shell/3.30/gnome-shell-light.css
@@ -2349,9 +2349,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 72px;
-  min-width: 72px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;

--- a/src/gnome-shell/3.30/gnome-shell.css
+++ b/src/gnome-shell/3.30/gnome-shell.css
@@ -2349,9 +2349,9 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .keyboard-key {
-  min-height: 72px;
-  min-width: 72px;
-  font-size: 2em;
+  min-height: 45px;
+  min-width: 45px;
+  font-size: 1.5em;
   font-weight: 500;
   border-radius: 4px;
   border: none;


### PR DESCRIPTION
Fixes issue #281 
![screenshot from 2018-11-21 16-52-49](https://user-images.githubusercontent.com/15423808/48852925-b0bbf300-edae-11e8-9746-133502a6a436.png)
![screenshot from 2018-11-21 16-53-04](https://user-images.githubusercontent.com/15423808/48852926-b3b6e380-edae-11e8-9762-1e02bfef1bed.png)
