### PR TITLE
gtk: tweak visibility of Ubiquity #label_page label

### DIFF
--- a/src/_sass/gtk/apps/_gnome-3.22.scss
+++ b/src/_sass/gtk/apps/_gnome-3.22.scss
@@ -1006,3 +1006,8 @@ button.title label { min-height: $medium-size; }
 
   &:dir(rtl) { margin-right: -5px; }
 }
+
+/*************
+ * Ubitquity *
+ *************/
+#live_installer #label_page { color: $solid-text; }


### PR DESCRIPTION
In Ubiquity the label #label_page is grey on a gray background and lacks
of visibility, use `solid-text` color instead.

Before
![Screenshot from 2019-03-28 23-21-41](https://user-images.githubusercontent.com/2883614/55196644-48dc4580-51b0-11e9-870e-29053106cb35.png)


After
![Screenshot from 2019-03-28 23-18-01](https://user-images.githubusercontent.com/2883614/55196505-e2572780-51af-11e9-9675-4ea57810b5fa.png)
