### PR TITLE
Fix install.sh (#416) unbound variable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -146,6 +146,8 @@ install_gdm() {
   fi
 }
 
+colors=()
+sizes=()
 while [[ "$#" -gt 0 ]]; do
   case "${1:-}" in
     -d|--dest)


### PR DESCRIPTION
initialize `colors` and `sizes` as an empty array in order to avoid `unbound variable` when running `install.sh` without  `--color` and `--size` arguments.