### PR TITLE
Fix/workaround for GNOME shell 3.32+ drop shadow cutoff bug

### DIFF
--- a/src/_sass/gnome-shell/_common-3.32.scss
+++ b/src/_sass/gnome-shell/_common-3.32.scss
@@ -237,7 +237,7 @@ StScrollBar {
   color: $text;
   background-color: $surface;
   border: none;
-  box-shadow: $shadow-4;
+  box-shadow: none;
   .modal-dialog-content-box {
     padding: 24px;
   }
@@ -618,8 +618,7 @@ StScrollBar {
     width: 16px;
     height: 16px;
   }
-  .popup-menu-boxpointer,
-  .candidate-popup-boxpointer {
+  .popup-menu-boxpointer {
     -arrow-border-radius: 20px; // This is necessary for the weird bug: materia-theme#296
     -arrow-background-color: transparent;
     -arrow-border-width: 0;
@@ -627,10 +626,26 @@ StScrollBar {
     -arrow-base: 0;
     -arrow-rise: 0;
     -arrow-box-shadow: none; //dreaming. bug #689995
-    margin: 5px 8px 8px;
-    background-color: $surface;
-    border-radius: $corner-radius;
-    box-shadow: $shadow-2;
+
+    .popup-menu-content { 
+      margin: 5px 8px 8px;
+      background-color: $surface;
+      border-radius: $corner-radius;
+      box-shadow: $shadow-2; 
+    }
+  }
+
+  .candidate-popup-boxpointer {
+    -arrow-background-color: transparent;
+    border: 0 none transparent;
+    background: transparent;
+
+    .candidate-popup-content {
+      margin: 5px 8px 8px;
+      background-color: $surface;
+      border-radius: $corner-radius;
+      box-shadow: $shadow-2; 
+    }
   }
 
   .popup-separator-menu-item {

--- a/src/gnome-shell/3.18/gnome-shell-compact.css
+++ b/src/gnome-shell/3.18/gnome-shell-compact.css
@@ -1079,7 +1079,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1519,13 +1519,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1574,7 +1574,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2129,7 +2129,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2185,7 +2185,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2496,7 +2496,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.18/gnome-shell-dark-compact.css
+++ b/src/gnome-shell/3.18/gnome-shell-dark-compact.css
@@ -1079,7 +1079,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1519,13 +1519,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1574,7 +1574,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2129,7 +2129,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2185,7 +2185,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2496,7 +2496,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.18/gnome-shell-dark.css
+++ b/src/gnome-shell/3.18/gnome-shell-dark.css
@@ -1079,7 +1079,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1519,13 +1519,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1574,7 +1574,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2129,7 +2129,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2185,7 +2185,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2496,7 +2496,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.18/gnome-shell-light-compact.css
+++ b/src/gnome-shell/3.18/gnome-shell-light-compact.css
@@ -1079,7 +1079,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1519,13 +1519,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1574,7 +1574,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2129,7 +2129,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2185,7 +2185,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2496,7 +2496,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.18/gnome-shell-light.css
+++ b/src/gnome-shell/3.18/gnome-shell-light.css
@@ -1079,7 +1079,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1519,13 +1519,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1574,7 +1574,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2129,7 +2129,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2185,7 +2185,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2496,7 +2496,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.18/gnome-shell.css
+++ b/src/gnome-shell/3.18/gnome-shell.css
@@ -1079,7 +1079,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1519,13 +1519,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1574,7 +1574,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2129,7 +2129,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2185,7 +2185,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2496,7 +2496,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.24/gnome-shell-compact.css
+++ b/src/gnome-shell/3.24/gnome-shell-compact.css
@@ -1087,7 +1087,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1422,7 +1422,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1446,7 +1446,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1566,13 +1566,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1621,7 +1621,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2176,7 +2176,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2232,7 +2232,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2543,7 +2543,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.24/gnome-shell-dark-compact.css
+++ b/src/gnome-shell/3.24/gnome-shell-dark-compact.css
@@ -1087,7 +1087,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1422,7 +1422,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: white;
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1446,7 +1446,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1566,13 +1566,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1621,7 +1621,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2176,7 +2176,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2232,7 +2232,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2543,7 +2543,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.24/gnome-shell-dark.css
+++ b/src/gnome-shell/3.24/gnome-shell-dark.css
@@ -1087,7 +1087,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1422,7 +1422,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: white;
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1446,7 +1446,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1566,13 +1566,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1621,7 +1621,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2176,7 +2176,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2232,7 +2232,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2543,7 +2543,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.24/gnome-shell-light-compact.css
+++ b/src/gnome-shell/3.24/gnome-shell-light-compact.css
@@ -1087,7 +1087,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1422,7 +1422,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1446,7 +1446,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1566,13 +1566,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1621,7 +1621,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2176,7 +2176,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2232,7 +2232,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2543,7 +2543,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.24/gnome-shell-light.css
+++ b/src/gnome-shell/3.24/gnome-shell-light.css
@@ -1087,7 +1087,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1422,7 +1422,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1446,7 +1446,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1566,13 +1566,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1621,7 +1621,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2176,7 +2176,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2232,7 +2232,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2543,7 +2543,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.24/gnome-shell.css
+++ b/src/gnome-shell/3.24/gnome-shell.css
@@ -1087,7 +1087,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1422,7 +1422,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1446,7 +1446,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1566,13 +1566,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1621,7 +1621,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2176,7 +2176,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2232,7 +2232,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2543,7 +2543,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.26/gnome-shell-compact.css
+++ b/src/gnome-shell/3.26/gnome-shell-compact.css
@@ -1089,7 +1089,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1455,7 +1455,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1479,7 +1479,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1599,13 +1599,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1654,7 +1654,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2208,7 +2208,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2264,7 +2264,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2520,7 +2520,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.26/gnome-shell-dark-compact.css
+++ b/src/gnome-shell/3.26/gnome-shell-dark-compact.css
@@ -1089,7 +1089,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1455,7 +1455,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: white;
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1479,7 +1479,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1599,13 +1599,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1654,7 +1654,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2208,7 +2208,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2264,7 +2264,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2520,7 +2520,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.26/gnome-shell-dark.css
+++ b/src/gnome-shell/3.26/gnome-shell-dark.css
@@ -1089,7 +1089,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1455,7 +1455,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: white;
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1479,7 +1479,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1599,13 +1599,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1654,7 +1654,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2208,7 +2208,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2264,7 +2264,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2520,7 +2520,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.26/gnome-shell-light-compact.css
+++ b/src/gnome-shell/3.26/gnome-shell-light-compact.css
@@ -1089,7 +1089,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1455,7 +1455,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1479,7 +1479,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1599,13 +1599,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1654,7 +1654,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2208,7 +2208,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2264,7 +2264,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2520,7 +2520,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.26/gnome-shell-light.css
+++ b/src/gnome-shell/3.26/gnome-shell-light.css
@@ -1089,7 +1089,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1455,7 +1455,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1479,7 +1479,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1599,13 +1599,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1654,7 +1654,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2208,7 +2208,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2264,7 +2264,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2520,7 +2520,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.26/gnome-shell.css
+++ b/src/gnome-shell/3.26/gnome-shell.css
@@ -1089,7 +1089,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1455,7 +1455,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1479,7 +1479,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1599,13 +1599,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1654,7 +1654,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2208,7 +2208,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2264,7 +2264,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2520,7 +2520,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.28/gnome-shell-compact.css
+++ b/src/gnome-shell/3.28/gnome-shell-compact.css
@@ -1089,7 +1089,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1455,7 +1455,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1479,7 +1479,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1599,13 +1599,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1654,7 +1654,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2208,7 +2208,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2264,7 +2264,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2563,7 +2563,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.28/gnome-shell-dark-compact.css
+++ b/src/gnome-shell/3.28/gnome-shell-dark-compact.css
@@ -1089,7 +1089,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1455,7 +1455,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: white;
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1479,7 +1479,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1599,13 +1599,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1654,7 +1654,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2208,7 +2208,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2264,7 +2264,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2563,7 +2563,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.28/gnome-shell-dark.css
+++ b/src/gnome-shell/3.28/gnome-shell-dark.css
@@ -1089,7 +1089,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1455,7 +1455,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: white;
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1479,7 +1479,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1599,13 +1599,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1654,7 +1654,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2208,7 +2208,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2264,7 +2264,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2563,7 +2563,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.28/gnome-shell-light-compact.css
+++ b/src/gnome-shell/3.28/gnome-shell-light-compact.css
@@ -1089,7 +1089,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1455,7 +1455,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1479,7 +1479,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1599,13 +1599,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1654,7 +1654,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2208,7 +2208,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2264,7 +2264,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2563,7 +2563,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.28/gnome-shell-light.css
+++ b/src/gnome-shell/3.28/gnome-shell-light.css
@@ -1089,7 +1089,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1455,7 +1455,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1479,7 +1479,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1599,13 +1599,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1654,7 +1654,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2208,7 +2208,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2264,7 +2264,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2563,7 +2563,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.28/gnome-shell.css
+++ b/src/gnome-shell/3.28/gnome-shell.css
@@ -1089,7 +1089,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1455,7 +1455,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1479,7 +1479,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1599,13 +1599,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1654,7 +1654,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2208,7 +2208,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2264,7 +2264,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2563,7 +2563,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.30/gnome-shell-compact.css
+++ b/src/gnome-shell/3.30/gnome-shell-compact.css
@@ -1090,7 +1090,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1461,7 +1461,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1485,7 +1485,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1605,13 +1605,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1661,7 +1661,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2215,7 +2215,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2271,7 +2271,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2570,7 +2570,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.30/gnome-shell-dark-compact.css
+++ b/src/gnome-shell/3.30/gnome-shell-dark-compact.css
@@ -1090,7 +1090,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1461,7 +1461,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: white;
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1485,7 +1485,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1605,13 +1605,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1661,7 +1661,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2215,7 +2215,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2271,7 +2271,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2570,7 +2570,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.30/gnome-shell-dark.css
+++ b/src/gnome-shell/3.30/gnome-shell-dark.css
@@ -1090,7 +1090,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1461,7 +1461,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: white;
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1485,7 +1485,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1605,13 +1605,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1661,7 +1661,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2215,7 +2215,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2271,7 +2271,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2570,7 +2570,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.30/gnome-shell-light-compact.css
+++ b/src/gnome-shell/3.30/gnome-shell-light-compact.css
@@ -1090,7 +1090,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1461,7 +1461,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1485,7 +1485,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1605,13 +1605,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1661,7 +1661,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2215,7 +2215,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2271,7 +2271,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2570,7 +2570,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.30/gnome-shell-light.css
+++ b/src/gnome-shell/3.30/gnome-shell-light.css
@@ -1090,7 +1090,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1461,7 +1461,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1485,7 +1485,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1605,13 +1605,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1661,7 +1661,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2215,7 +2215,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2271,7 +2271,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2570,7 +2570,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.30/gnome-shell.css
+++ b/src/gnome-shell/3.30/gnome-shell.css
@@ -1090,7 +1090,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1461,7 +1461,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1485,7 +1485,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1605,13 +1605,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1661,7 +1661,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2215,7 +2215,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2271,7 +2271,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2570,7 +2570,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.32/gnome-shell-compact.css
+++ b/src/gnome-shell/3.32/gnome-shell-compact.css
@@ -357,7 +357,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
   border: none;
-  box-shadow: 0 14px 14px rgba(0, 0, 0, 0.5), 0 10px 5px rgba(0, 0, 0, 0.44);
+  box-shadow: none;
 }
 
 .modal-dialog .modal-dialog-content-box {
@@ -806,8 +806,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   height: 16px;
 }
 
-.popup-menu-boxpointer,
-.candidate-popup-boxpointer {
+.popup-menu-boxpointer {
   -arrow-border-radius: 20px;
   -arrow-background-color: transparent;
   -arrow-border-width: 0;
@@ -815,6 +814,22 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   -arrow-base: 0;
   -arrow-rise: 0;
   -arrow-box-shadow: none;
+}
+
+.popup-menu-boxpointer .popup-menu-content {
+  margin: 5px 8px 8px;
+  background-color: #FFFFFF;
+  border-radius: 4px;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 3px 3px rgba(0, 0, 0, 0.345);
+}
+
+.candidate-popup-boxpointer {
+  -arrow-background-color: transparent;
+  border: 0 none transparent;
+  background: transparent;
+}
+
+.candidate-popup-boxpointer .candidate-popup-content {
   margin: 5px 8px 8px;
   background-color: #FFFFFF;
   border-radius: 4px;
@@ -1080,7 +1095,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1280,7 +1295,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .weather-forecast-icon {
-  icon-size: 2.28571em;
+  icon-size: 2.2857142857em;
 }
 
 .weather-forecast-time {
@@ -1326,7 +1341,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .calendar-change-month-back StIcon, .calendar-change-month-forward StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .calendar-day-base {
@@ -1475,7 +1490,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1485,8 +1500,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-icon-bin > .fallback-window-icon {
-  width: 1.14286em;
-  height: 1.14286em;
+  width: 1.1428571429em;
+  height: 1.1428571429em;
 }
 
 .message-secondary-bin {
@@ -1504,7 +1519,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1624,13 +1639,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1681,11 +1696,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-arrow {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2260,7 +2275,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2316,7 +2331,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2660,7 +2675,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.32/gnome-shell-dark-compact.css
+++ b/src/gnome-shell/3.32/gnome-shell-dark-compact.css
@@ -357,7 +357,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: white;
   background-color: #3C3C3C;
   border: none;
-  box-shadow: 0 14px 14px rgba(0, 0, 0, 0.5), 0 10px 5px rgba(0, 0, 0, 0.44);
+  box-shadow: none;
 }
 
 .modal-dialog .modal-dialog-content-box {
@@ -806,8 +806,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   height: 16px;
 }
 
-.popup-menu-boxpointer,
-.candidate-popup-boxpointer {
+.popup-menu-boxpointer {
   -arrow-border-radius: 20px;
   -arrow-background-color: transparent;
   -arrow-border-width: 0;
@@ -815,6 +814,22 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   -arrow-base: 0;
   -arrow-rise: 0;
   -arrow-box-shadow: none;
+}
+
+.popup-menu-boxpointer .popup-menu-content {
+  margin: 5px 8px 8px;
+  background-color: #3C3C3C;
+  border-radius: 4px;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 3px 3px rgba(0, 0, 0, 0.345);
+}
+
+.candidate-popup-boxpointer {
+  -arrow-background-color: transparent;
+  border: 0 none transparent;
+  background: transparent;
+}
+
+.candidate-popup-boxpointer .candidate-popup-content {
   margin: 5px 8px 8px;
   background-color: #3C3C3C;
   border-radius: 4px;
@@ -1080,7 +1095,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1280,7 +1295,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .weather-forecast-icon {
-  icon-size: 2.28571em;
+  icon-size: 2.2857142857em;
 }
 
 .weather-forecast-time {
@@ -1326,7 +1341,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .calendar-change-month-back StIcon, .calendar-change-month-forward StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .calendar-day-base {
@@ -1475,7 +1490,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: white;
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1485,8 +1500,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-icon-bin > .fallback-window-icon {
-  width: 1.14286em;
-  height: 1.14286em;
+  width: 1.1428571429em;
+  height: 1.1428571429em;
 }
 
 .message-secondary-bin {
@@ -1504,7 +1519,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1624,13 +1639,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1681,11 +1696,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-arrow {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2260,7 +2275,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2316,7 +2331,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2660,7 +2675,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.32/gnome-shell-dark.css
+++ b/src/gnome-shell/3.32/gnome-shell-dark.css
@@ -357,7 +357,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: white;
   background-color: #3C3C3C;
   border: none;
-  box-shadow: 0 14px 14px rgba(0, 0, 0, 0.5), 0 10px 5px rgba(0, 0, 0, 0.44);
+  box-shadow: none;
 }
 
 .modal-dialog .modal-dialog-content-box {
@@ -806,8 +806,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   height: 16px;
 }
 
-.popup-menu-boxpointer,
-.candidate-popup-boxpointer {
+.popup-menu-boxpointer {
   -arrow-border-radius: 20px;
   -arrow-background-color: transparent;
   -arrow-border-width: 0;
@@ -815,6 +814,22 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   -arrow-base: 0;
   -arrow-rise: 0;
   -arrow-box-shadow: none;
+}
+
+.popup-menu-boxpointer .popup-menu-content {
+  margin: 5px 8px 8px;
+  background-color: #3C3C3C;
+  border-radius: 4px;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 3px 3px rgba(0, 0, 0, 0.345);
+}
+
+.candidate-popup-boxpointer {
+  -arrow-background-color: transparent;
+  border: 0 none transparent;
+  background: transparent;
+}
+
+.candidate-popup-boxpointer .candidate-popup-content {
   margin: 5px 8px 8px;
   background-color: #3C3C3C;
   border-radius: 4px;
@@ -1080,7 +1095,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1280,7 +1295,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .weather-forecast-icon {
-  icon-size: 2.28571em;
+  icon-size: 2.2857142857em;
 }
 
 .weather-forecast-time {
@@ -1326,7 +1341,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .calendar-change-month-back StIcon, .calendar-change-month-forward StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .calendar-day-base {
@@ -1475,7 +1490,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: white;
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1485,8 +1500,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-icon-bin > .fallback-window-icon {
-  width: 1.14286em;
-  height: 1.14286em;
+  width: 1.1428571429em;
+  height: 1.1428571429em;
 }
 
 .message-secondary-bin {
@@ -1504,7 +1519,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1624,13 +1639,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1681,11 +1696,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-arrow {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2260,7 +2275,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2316,7 +2331,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2660,7 +2675,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.32/gnome-shell-light-compact.css
+++ b/src/gnome-shell/3.32/gnome-shell-light-compact.css
@@ -357,7 +357,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
   border: none;
-  box-shadow: 0 14px 14px rgba(0, 0, 0, 0.5), 0 10px 5px rgba(0, 0, 0, 0.44);
+  box-shadow: none;
 }
 
 .modal-dialog .modal-dialog-content-box {
@@ -806,8 +806,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   height: 16px;
 }
 
-.popup-menu-boxpointer,
-.candidate-popup-boxpointer {
+.popup-menu-boxpointer {
   -arrow-border-radius: 20px;
   -arrow-background-color: transparent;
   -arrow-border-width: 0;
@@ -815,6 +814,22 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   -arrow-base: 0;
   -arrow-rise: 0;
   -arrow-box-shadow: none;
+}
+
+.popup-menu-boxpointer .popup-menu-content {
+  margin: 5px 8px 8px;
+  background-color: #FFFFFF;
+  border-radius: 4px;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 3px 3px rgba(0, 0, 0, 0.345);
+}
+
+.candidate-popup-boxpointer {
+  -arrow-background-color: transparent;
+  border: 0 none transparent;
+  background: transparent;
+}
+
+.candidate-popup-boxpointer .candidate-popup-content {
   margin: 5px 8px 8px;
   background-color: #FFFFFF;
   border-radius: 4px;
@@ -1080,7 +1095,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1280,7 +1295,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .weather-forecast-icon {
-  icon-size: 2.28571em;
+  icon-size: 2.2857142857em;
 }
 
 .weather-forecast-time {
@@ -1326,7 +1341,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .calendar-change-month-back StIcon, .calendar-change-month-forward StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .calendar-day-base {
@@ -1475,7 +1490,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1485,8 +1500,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-icon-bin > .fallback-window-icon {
-  width: 1.14286em;
-  height: 1.14286em;
+  width: 1.1428571429em;
+  height: 1.1428571429em;
 }
 
 .message-secondary-bin {
@@ -1504,7 +1519,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1624,13 +1639,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1681,11 +1696,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-arrow {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2260,7 +2275,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2316,7 +2331,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2660,7 +2675,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.32/gnome-shell-light.css
+++ b/src/gnome-shell/3.32/gnome-shell-light.css
@@ -357,7 +357,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
   border: none;
-  box-shadow: 0 14px 14px rgba(0, 0, 0, 0.5), 0 10px 5px rgba(0, 0, 0, 0.44);
+  box-shadow: none;
 }
 
 .modal-dialog .modal-dialog-content-box {
@@ -806,8 +806,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   height: 16px;
 }
 
-.popup-menu-boxpointer,
-.candidate-popup-boxpointer {
+.popup-menu-boxpointer {
   -arrow-border-radius: 20px;
   -arrow-background-color: transparent;
   -arrow-border-width: 0;
@@ -815,6 +814,22 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   -arrow-base: 0;
   -arrow-rise: 0;
   -arrow-box-shadow: none;
+}
+
+.popup-menu-boxpointer .popup-menu-content {
+  margin: 5px 8px 8px;
+  background-color: #FFFFFF;
+  border-radius: 4px;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 3px 3px rgba(0, 0, 0, 0.345);
+}
+
+.candidate-popup-boxpointer {
+  -arrow-background-color: transparent;
+  border: 0 none transparent;
+  background: transparent;
+}
+
+.candidate-popup-boxpointer .candidate-popup-content {
   margin: 5px 8px 8px;
   background-color: #FFFFFF;
   border-radius: 4px;
@@ -1080,7 +1095,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1280,7 +1295,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .weather-forecast-icon {
-  icon-size: 2.28571em;
+  icon-size: 2.2857142857em;
 }
 
 .weather-forecast-time {
@@ -1326,7 +1341,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .calendar-change-month-back StIcon, .calendar-change-month-forward StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .calendar-day-base {
@@ -1475,7 +1490,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1485,8 +1500,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-icon-bin > .fallback-window-icon {
-  width: 1.14286em;
-  height: 1.14286em;
+  width: 1.1428571429em;
+  height: 1.1428571429em;
 }
 
 .message-secondary-bin {
@@ -1504,7 +1519,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1624,13 +1639,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1681,11 +1696,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-arrow {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2260,7 +2275,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2316,7 +2331,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2660,7 +2675,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gnome-shell/3.32/gnome-shell.css
+++ b/src/gnome-shell/3.32/gnome-shell.css
@@ -357,7 +357,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   color: rgba(0, 0, 0, 0.87);
   background-color: #FFFFFF;
   border: none;
-  box-shadow: 0 14px 14px rgba(0, 0, 0, 0.5), 0 10px 5px rgba(0, 0, 0, 0.44);
+  box-shadow: none;
 }
 
 .modal-dialog .modal-dialog-content-box {
@@ -806,8 +806,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   height: 16px;
 }
 
-.popup-menu-boxpointer,
-.candidate-popup-boxpointer {
+.popup-menu-boxpointer {
   -arrow-border-radius: 20px;
   -arrow-background-color: transparent;
   -arrow-border-width: 0;
@@ -815,6 +814,22 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   -arrow-base: 0;
   -arrow-rise: 0;
   -arrow-box-shadow: none;
+}
+
+.popup-menu-boxpointer .popup-menu-content {
+  margin: 5px 8px 8px;
+  background-color: #FFFFFF;
+  border-radius: 4px;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.24), 0 3px 3px rgba(0, 0, 0, 0.345);
+}
+
+.candidate-popup-boxpointer {
+  -arrow-background-color: transparent;
+  border: 0 none transparent;
+  background: transparent;
+}
+
+.candidate-popup-boxpointer .candidate-popup-content {
   margin: 5px 8px 8px;
   background-color: #FFFFFF;
   border-radius: 4px;
@@ -1080,7 +1095,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 #panel .panel-button .system-status-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   padding: 0 4px;
 }
 
@@ -1280,7 +1295,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .weather-forecast-icon {
-  icon-size: 2.28571em;
+  icon-size: 2.2857142857em;
 }
 
 .weather-forecast-time {
@@ -1326,7 +1341,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .calendar-change-month-back StIcon, .calendar-change-month-forward StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .calendar-day-base {
@@ -1475,7 +1490,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .message-icon-bin > StIcon {
   color: rgba(0, 0, 0, 0.87);
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
   -st-icon-style: requested;
   margin: 4px 0px 4px 4px;
 }
@@ -1485,8 +1500,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-icon-bin > .fallback-window-icon {
-  width: 1.14286em;
-  height: 1.14286em;
+  width: 1.1428571429em;
+  height: 1.1428571429em;
 }
 
 .message-secondary-bin {
@@ -1504,7 +1519,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .message-secondary-bin > StIcon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .message-title {
@@ -1624,13 +1639,13 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:ltr {
   /* 8px spacing + 2*4px padding */
   padding-left: 16px;
-  margin-left: 1.14286em;
+  margin-left: 1.1428571429em;
 }
 
 .aggregate-menu .popup-sub-menu .popup-menu-item > :first-child:rtl {
   /* 8px spacing + 2*4px padding */
   padding-right: 16px;
-  margin-right: 1.14286em;
+  margin-right: 1.1428571429em;
 }
 
 .system-menu-action {
@@ -1681,11 +1696,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .popup-menu-arrow {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .popup-menu-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .window-close {
@@ -2260,7 +2275,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .notification-banner .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .notification-banner .notification-actions {
@@ -2316,7 +2331,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .secondary-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 .chat-body {
@@ -2660,7 +2675,7 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 }
 
 .candidate-page-button-icon {
-  icon-size: 1.14286em;
+  icon-size: 1.1428571429em;
 }
 
 /* Auth Dialogs & Screen Shield */

--- a/src/gtk/3.0/gtk-compact.css
+++ b/src/gtk/3.0/gtk-compact.css
@@ -70,7 +70,7 @@
 }
 
 .gtkstyle-fallback:active {
-  background-color: #d9d9d9;
+  background-color: #d9d8d8;
   color: rgba(0, 0, 0, 0.87);
 }
 

--- a/src/gtk/3.0/gtk-dark-compact.css
+++ b/src/gtk/3.0/gtk-dark-compact.css
@@ -70,7 +70,7 @@
 }
 
 .gtkstyle-fallback:active {
-  background-color: #080808;
+  background-color: #080707;
   color: white;
 }
 

--- a/src/gtk/3.0/gtk-dark.css
+++ b/src/gtk/3.0/gtk-dark.css
@@ -70,7 +70,7 @@
 }
 
 .gtkstyle-fallback:active {
-  background-color: #080808;
+  background-color: #080707;
   color: white;
 }
 

--- a/src/gtk/3.0/gtk-light-compact.css
+++ b/src/gtk/3.0/gtk-light-compact.css
@@ -70,7 +70,7 @@
 }
 
 .gtkstyle-fallback:active {
-  background-color: #d9d9d9;
+  background-color: #d9d8d8;
   color: rgba(0, 0, 0, 0.87);
 }
 

--- a/src/gtk/3.0/gtk-light.css
+++ b/src/gtk/3.0/gtk-light.css
@@ -70,7 +70,7 @@
 }
 
 .gtkstyle-fallback:active {
-  background-color: #d9d9d9;
+  background-color: #d9d8d8;
   color: rgba(0, 0, 0, 0.87);
 }
 

--- a/src/gtk/3.0/gtk.css
+++ b/src/gtk/3.0/gtk.css
@@ -70,7 +70,7 @@
 }
 
 .gtkstyle-fallback:active {
-  background-color: #d9d9d9;
+  background-color: #d9d8d8;
   color: rgba(0, 0, 0, 0.87);
 }
 


### PR DESCRIPTION
Fix/workaround for #364 

It only affects popover menus only, while modal dialog drop shadows are completely removed (needs to replaced with SVG asset overlay, GS < 3.32 should not affected)

It was based how [plata-theme](https://gitlab.com/tista500/plata-theme) did for dealing with this bug
