### PR TITLE
gtk: Improve avatar visiblity in Fractal

### DIFF
--- a/src/_sass/gtk/apps/_gnome-3.22.scss
+++ b/src/_sass/gtk/apps/_gnome-3.22.scss
@@ -1010,3 +1010,12 @@ button.title label { min-height: $medium-size; }
 
   &:dir(rtl) { margin-right: -5px; }
 }
+
+
+/***********
+ * Fractal *
+ ***********/
+// Improve avatar visibility on selected row in light themes
+@if $variant == light {
+  .room-list list row:selected .direct-chat { -gtk-icon-shadow: 0 0 black, 0 0 black; }
+}

--- a/src/gtk/3.0/gtk-compact.css
+++ b/src/gtk/3.0/gtk-compact.css
@@ -4816,6 +4816,13 @@ button.title label {
   margin-right: -5px;
 }
 
+/***********
+ * Fractal *
+ ***********/
+.room-list list row:selected .direct-chat {
+  -gtk-icon-shadow: 0 0 black, 0 0 black;
+}
+
 /*********
  * Tilix *
  *********/

--- a/src/gtk/3.0/gtk-dark-compact.css
+++ b/src/gtk/3.0/gtk-dark-compact.css
@@ -4816,6 +4816,9 @@ button.title label {
   margin-right: -5px;
 }
 
+/***********
+ * Fractal *
+ ***********/
 /*********
  * Tilix *
  *********/

--- a/src/gtk/3.0/gtk-dark.css
+++ b/src/gtk/3.0/gtk-dark.css
@@ -4816,6 +4816,9 @@ button.title label {
   margin-right: -5px;
 }
 
+/***********
+ * Fractal *
+ ***********/
 /*********
  * Tilix *
  *********/

--- a/src/gtk/3.0/gtk-light-compact.css
+++ b/src/gtk/3.0/gtk-light-compact.css
@@ -4816,6 +4816,13 @@ button.title label {
   margin-right: -5px;
 }
 
+/***********
+ * Fractal *
+ ***********/
+.room-list list row:selected .direct-chat {
+  -gtk-icon-shadow: 0 0 black, 0 0 black;
+}
+
 /*********
  * Tilix *
  *********/

--- a/src/gtk/3.0/gtk-light.css
+++ b/src/gtk/3.0/gtk-light.css
@@ -4816,6 +4816,13 @@ button.title label {
   margin-right: -5px;
 }
 
+/***********
+ * Fractal *
+ ***********/
+.room-list list row:selected .direct-chat {
+  -gtk-icon-shadow: 0 0 black, 0 0 black;
+}
+
 /*********
  * Tilix *
  *********/

--- a/src/gtk/3.0/gtk.css
+++ b/src/gtk/3.0/gtk.css
@@ -4816,6 +4816,13 @@ button.title label {
   margin-right: -5px;
 }
 
+/***********
+ * Fractal *
+ ***********/
+.room-list list row:selected .direct-chat {
+  -gtk-icon-shadow: 0 0 black, 0 0 black;
+}
+
 /*********
  * Tilix *
  *********/


### PR DESCRIPTION
Small hack, we can't change avatar color (it's in fractal's css), but we could add double shadow (triple+ shadows looks worse). Before/after:

![m1](https://user-images.githubusercontent.com/42862490/68091075-27a5ab00-fe9d-11e9-9a94-bc1be72206e5.png)
![m2](https://user-images.githubusercontent.com/42862490/68091077-2aa09b80-fe9d-11e9-921a-689cb534bb0b.png)

p.s.: Looks like button margins also need some adjustments.