### PR TITLE
gtk: Fix selected text color in Evince

### DIFF
--- a/src/_sass/gtk/apps/_gnome-3.22.scss
+++ b/src/_sass/gtk/apps/_gnome-3.22.scss
@@ -1010,3 +1010,14 @@ button.title label { min-height: $medium-size; }
 
   &:dir(rtl) { margin-right: -5px; }
 }
+
+
+/**********
+ * Evince *
+ **********/
+// Color is needed for Evince to match hardcoded background-color,
+// since Documents app is also uses this style, background-color needs to be set accordingly.
+evview.content-view.view:selected  {
+  background-color: $primary;
+  color: on($primary);
+}

--- a/src/gtk/3.0/gtk-compact.css
+++ b/src/gtk/3.0/gtk-compact.css
@@ -4816,6 +4816,14 @@ button.title label {
   margin-right: -5px;
 }
 
+/**********
+ * Evince *
+ **********/
+evview.content-view.view:selected {
+  background-color: #1A73E8;
+  color: white;
+}
+
 /*********
  * Tilix *
  *********/

--- a/src/gtk/3.0/gtk-dark-compact.css
+++ b/src/gtk/3.0/gtk-dark-compact.css
@@ -4816,6 +4816,14 @@ button.title label {
   margin-right: -5px;
 }
 
+/**********
+ * Evince *
+ **********/
+evview.content-view.view:selected {
+  background-color: #8AB4F8;
+  color: rgba(0, 0, 0, 0.87);
+}
+
 /*********
  * Tilix *
  *********/

--- a/src/gtk/3.0/gtk-dark.css
+++ b/src/gtk/3.0/gtk-dark.css
@@ -4816,6 +4816,14 @@ button.title label {
   margin-right: -5px;
 }
 
+/**********
+ * Evince *
+ **********/
+evview.content-view.view:selected {
+  background-color: #8AB4F8;
+  color: rgba(0, 0, 0, 0.87);
+}
+
 /*********
  * Tilix *
  *********/

--- a/src/gtk/3.0/gtk-light-compact.css
+++ b/src/gtk/3.0/gtk-light-compact.css
@@ -4816,6 +4816,14 @@ button.title label {
   margin-right: -5px;
 }
 
+/**********
+ * Evince *
+ **********/
+evview.content-view.view:selected {
+  background-color: #1A73E8;
+  color: white;
+}
+
 /*********
  * Tilix *
  *********/

--- a/src/gtk/3.0/gtk-light.css
+++ b/src/gtk/3.0/gtk-light.css
@@ -4816,6 +4816,14 @@ button.title label {
   margin-right: -5px;
 }
 
+/**********
+ * Evince *
+ **********/
+evview.content-view.view:selected {
+  background-color: #1A73E8;
+  color: white;
+}
+
 /*********
  * Tilix *
  *********/

--- a/src/gtk/3.0/gtk.css
+++ b/src/gtk/3.0/gtk.css
@@ -4816,6 +4816,14 @@ button.title label {
   margin-right: -5px;
 }
 
+/**********
+ * Evince *
+ **********/
+evview.content-view.view:selected {
+  background-color: #1A73E8;
+  color: white;
+}
+
 /*********
  * Tilix *
  *********/


### PR DESCRIPTION
It's not that bad actually, but not good either. [Upstream issue](https://gitlab.gnome.org/GNOME/evince/issues/1043). Documents app also uses evview, (iirc, no hardcoded values there - bg/fg colors are inherited from .view), so background-color also need to be set. 

before/after:  
![mm1](https://user-images.githubusercontent.com/42862490/68242961-58b7e400-0033-11ea-9095-ed64cfbecbd3.png)

![mm2](https://user-images.githubusercontent.com/42862490/68242962-58b7e400-0033-11ea-86a7-c8048a93cde3.png)

before/after:  
![mm3](https://user-images.githubusercontent.com/42862490/68242963-58b7e400-0033-11ea-853e-a58451120670.png)

![mm4](https://user-images.githubusercontent.com/42862490/68242964-59507a80-0033-11ea-90f6-b9c7a26cd6d2.png)

Also, i accidentally pressed fullscreen button, and looks like page-count/zoom-value enties lacks solid background (i assume you intentionally make top bar transparent).

![mm5](https://user-images.githubusercontent.com/42862490/68242965-59507a80-0033-11ea-892e-cbcd826b4c79.png)
