### PR TITLE
Update Gnome-shell calendar design

### DIFF
--- a/src/gnome-shell/assets-dark/calendar-event.svg
+++ b/src/gnome-shell/assets-dark/calendar-event.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="#FFFFFF" opacity="0.7">
+	<circle
+	cx="12"
+	cy="21"
+	r="1.5" />
+</svg>

--- a/src/gnome-shell/assets/calendar-event.svg
+++ b/src/gnome-shell/assets/calendar-event.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="#000000" opacity="0.54">
+	<circle
+	cx="12"
+	cy="21"
+	r="1.5" />
+</svg>

--- a/src/gnome-shell/sass/components/menu/_calendar.scss
+++ b/src/gnome-shell/sass/components/menu/_calendar.scss
@@ -183,6 +183,7 @@ $calendar-column-margin: 0 8px;
     @include type(caption);
     font-feature-settings: "tnum";
     text-align: center;
+    color: $text;
 
     &:focus {
       background-color: $overlay-focus;
@@ -242,11 +243,13 @@ $calendar-column-margin: 0 8px;
 
   .calendar-nonwork-day {
     color: inherit;
+    font-weight: bold;
   }
 
   // Today
   .calendar-today {
-    border: 0;
+    border: 1px solid $overlay-selected;
+    margin: 1px !important;
     background-color: transparent;
     color: inherit;
     font-weight: bold !important;
@@ -281,10 +284,7 @@ $calendar-column-margin: 0 8px;
   }
 
   .calendar-day-with-events {
-    background-image: none;
-    color: $primary !important;
-    font-weight: normal;
-    text-decoration: underline;
+    background-image: url("assets/calendar-event.svg");
   }
 
   .calendar-other-month-day {


### PR DESCRIPTION
Fixed a bug where the dark theme used dark text colors and improved design somewhat based on [Material picker component](https://material.io/components/pickers/)

![Screenshot](https://i.imgur.com/UQtlslB.png)