### PR TITLE
Replaced undershoot border from dashed to gradient

### DIFF
--- a/src/gnome-shell/sass/components/dialog/_dialog.scss
+++ b/src/gnome-shell/sass/components/dialog/_dialog.scss
@@ -263,6 +263,7 @@
     width: 28em;
 
     .modal-dialog-content-box {
+      text-align: center;
       margin-bottom: 24px;
     }
   }
@@ -303,6 +304,7 @@
     }
 
     .message-dialog-content {
+      text-align: center;
       spacing: 16px;
     }
 

--- a/src/gtk/sass/_drawing-3.20.scss
+++ b/src/gtk/sass/_drawing-3.20.scss
@@ -220,24 +220,27 @@ $ripple-active-transition-duration: $duration, $ripple-fade-in-duration, 0ms, 0m
   $_undershoot_color_light: transparent;
 
   $_gradient_dir: left;
-  $_dash_bg_size: 12px 1px;
+  $_dash_bg_size: 12px 5px;
   $_gradient_repeat: repeat-x;
   $_bg_pos: left $side;
 
   @if $side == left or $side == right {
-    $_gradient_dir: top;
-    $_dash_bg_size: 1px 12px;
+    $_dash_bg_size: 5px 12px;
     $_gradient_repeat: repeat-y;
     $_bg_pos: $side top;
   }
 
+  @if $side == top    { $_gradient_dir: bottom; }
+  @if $side == bottom { $_gradient_dir: top; }
+
+  @if $side == left   { $_gradient_dir: right; }
+  @if $side == right  { $_gradient_dir: left; }
+
   background-color: transparent; // shouldn't be needed, but better to be sure
 
-  background-image: linear-gradient(to $_gradient_dir, // this is the dashed line
-                                    $_undershoot_color_light 50%,
-                                    $_undershoot_color_dark 50%);
+  background-image: linear-gradient(to $_gradient_dir, $_undershoot_color_dark 5%, $_undershoot_color_light);
 
-  padding-#{$side}: 1px;
+  padding-#{$side}: 0px;
   background-size: $_dash_bg_size;
   background-repeat: $_gradient_repeat;
   background-origin: content-box;


### PR DESCRIPTION
Changed dashed border into a linear gradient under GTK.

I changed it since this theme is based on gradients and this one looks odd.

Original undershoot border:
![Screenshot from 2020-06-21 12-32-29](https://user-images.githubusercontent.com/76865/85216820-e296a080-b3bb-11ea-848f-d1ab859509de.png)

Modified undershoot border:
![Screenshot from 2020-06-21 12-33-17](https://user-images.githubusercontent.com/76865/85216831-0a860400-b3bc-11ea-9b29-21a4c19a1ab4.png)

