### PR TITLE
scripts: Carefully check if inkscape exists

### DIFF
--- a/src/chrome/render-asset.sh
+++ b/src/chrome/render-asset.sh
@@ -5,17 +5,20 @@ RENDER_SVG="$(command -v rendersvg)" || true
 INKSCAPE="$(command -v inkscape)" || true
 OPTIPNG="$(command -v optipng)" || true
 
-if "$INKSCAPE" --help | grep -e "--export-filename" > /dev/null; then
-  EXPORT_FILE_OPTION="--export-filename"
-elif "$INKSCAPE" --help | grep -e "--export-file" > /dev/null; then
-  EXPORT_FILE_OPTION="--export-file"
-elif "$INKSCAPE" --help | grep -e "--export-png" > /dev/null; then
-  EXPORT_FILE_OPTION="--export-png"
+if [[ -n "${INKSCAPE}" ]]; then
+  if "$INKSCAPE" --help | grep -e "--export-filename" > /dev/null; then
+    EXPORT_FILE_OPTION="--export-filename"
+  elif "$INKSCAPE" --help | grep -e "--export-file" > /dev/null; then
+    EXPORT_FILE_OPTION="--export-file"
+  elif "$INKSCAPE" --help | grep -e "--export-png" > /dev/null; then
+    EXPORT_FILE_OPTION="--export-png"
+  fi
 fi
 
 i="$1"
 
 echo "Rendering '$i.png'"
+
 if [[ -n "${RENDER_SVG}" ]]; then
   "$RENDER_SVG" --dpi 96 "$i.svg" "$i.png"
 else

--- a/src/gtk-2.0/render-asset.sh
+++ b/src/gtk-2.0/render-asset.sh
@@ -5,6 +5,16 @@ RENDER_SVG="$(command -v rendersvg)" || true
 INKSCAPE="$(command -v inkscape)" || true
 OPTIPNG="$(command -v optipng)" || true
 
+if [[ -n "${INKSCAPE}" ]]; then
+  if "$INKSCAPE" --help | grep -e "--export-filename" > /dev/null; then
+    EXPORT_FILE_OPTION="--export-filename"
+  elif "$INKSCAPE" --help | grep -e "--export-file" > /dev/null; then
+    EXPORT_FILE_OPTION="--export-file"
+  elif "$INKSCAPE" --help | grep -e "--export-png" > /dev/null; then
+    EXPORT_FILE_OPTION="--export-png"
+  fi
+fi
+
 if [[ "$1" == "dark" ]]; then
   SRC_FILE="assets-dark.svg"
   ASSETS_DIR="assets-dark"
@@ -26,6 +36,7 @@ else
 fi
 
 echo "Rendering '$ASSETS_DIR/$i.png'"
+
 if [[ -n "${RENDER_SVG}" ]]; then
   # @TODO: remove --zoom when it will be fixed/implemented in resvg
   "$RENDER_SVG" --export-id "$i" \
@@ -33,14 +44,6 @@ if [[ -n "${RENDER_SVG}" ]]; then
                 --zoom ${ZOOM} \
                 "$SRC_FILE" "$ASSETS_DIR/$i.png"
 else
-  if "$INKSCAPE" --help | grep -e "--export-filename" > /dev/null; then
-    EXPORT_FILE_OPTION="--export-filename"
-  elif "$INKSCAPE" --help | grep -e "--export-file" > /dev/null; then
-    EXPORT_FILE_OPTION="--export-file"
-  elif "$INKSCAPE" --help | grep -e "--export-png" > /dev/null; then
-    EXPORT_FILE_OPTION="--export-png"
-  fi
-
   "$INKSCAPE" --export-id="$i" \
               --export-id-only \
               --export-dpi=${DPI} \

--- a/src/gtk/render-asset.sh
+++ b/src/gtk/render-asset.sh
@@ -5,12 +5,14 @@ RENDER_SVG="$(command -v rendersvg)" || true
 INKSCAPE="$(command -v inkscape)" || true
 OPTIPNG="$(command -v optipng)" || true
 
-if "$INKSCAPE" --help | grep -e "--export-filename" > /dev/null; then
-  EXPORT_FILE_OPTION="--export-filename"
-elif "$INKSCAPE" --help | grep -e "--export-file" > /dev/null; then
-  EXPORT_FILE_OPTION="--export-file"
-elif "$INKSCAPE" --help | grep -e "--export-png" > /dev/null; then
-  EXPORT_FILE_OPTION="--export-png"
+if [[ -n "${INKSCAPE}" ]]; then
+  if "$INKSCAPE" --help | grep -e "--export-filename" > /dev/null; then
+    EXPORT_FILE_OPTION="--export-filename"
+  elif "$INKSCAPE" --help | grep -e "--export-file" > /dev/null; then
+    EXPORT_FILE_OPTION="--export-file"
+  elif "$INKSCAPE" --help | grep -e "--export-png" > /dev/null; then
+    EXPORT_FILE_OPTION="--export-png"
+  fi
 fi
 
 SRC_FILE="assets.svg"
@@ -19,6 +21,7 @@ ASSETS_DIR="assets"
 i="$1"
 
 echo "Rendering '$ASSETS_DIR/$i.png'"
+
 if [[ -n "${RENDER_SVG}" ]]; then
   "$RENDER_SVG" --export-id "$i" \
                 "$SRC_FILE" "$ASSETS_DIR/$i.png"
@@ -27,11 +30,13 @@ else
               --export-id-only \
               "$EXPORT_FILE_OPTION"="$ASSETS_DIR/$i.png" "$SRC_FILE" >/dev/null
 fi
+
 if [[ -n "${OPTIPNG}" ]]; then
   "$OPTIPNG" -o7 --quiet "$ASSETS_DIR/$i.png"
 fi
 
 echo "Rendering '$ASSETS_DIR/$i@2.png'"
+
 if [[ -n "${RENDER_SVG}" ]]; then
   # @TODO: remove --zoom when it will be fixed/implemented in resvg
   "$RENDER_SVG" --export-id "$i" \
@@ -44,6 +49,7 @@ else
               --export-dpi=192 \
               "$EXPORT_FILE_OPTION"="$ASSETS_DIR/$i@2.png" "$SRC_FILE" >/dev/null
 fi
+
 if [[ -n "${OPTIPNG}" ]]; then
   "$OPTIPNG" -o7 --quiet "$ASSETS_DIR/$i@2.png"
 fi


### PR DESCRIPTION
This prevents the scripts from exiting if `rendersvg` is installed but
`inkscape` is not.

And make sure `inkscape` is available when `rendersvg` is unavailable.