### PR TITLE
Increase alpha of overlay_selected

### DIFF
--- a/src/_colors.scss
+++ b/src/_colors.scss
@@ -196,7 +196,7 @@ $titlebar-indicator: currentcolor;
 // Overlay state colors
 //
 
-$overlay-selected: rgba($primary, .24);
+$overlay-selected: rgba($primary, .60);
 
 //
 // For “on” colors


### PR DESCRIPTION
Selection bacground color is indistinguishable in dark webpages.
Changed alpha of overlay_selected from .24 to .60

selecting the same text:

alpha = .24
![Screenshot from 2021-01-12 02-28-15](https://user-images.githubusercontent.com/52642831/104223018-0d426680-547e-11eb-894f-ff44050024bb.png)


alpha = .60
![Screenshot from 2021-01-12 02-28-54](https://user-images.githubusercontent.com/52642831/104223056-17646500-547e-11eb-897e-f3c2af821d9a.png)