### PR TITLE
Fix build error on Ubuntu 20.04: "add_install_script args must be strings"

### DIFF
--- a/src/cinnamon/meson.build
+++ b/src/cinnamon/meson.build
@@ -53,7 +53,7 @@ foreach theme: themes
 
   # Install it while renaming to a valid name
   meson.add_install_script(
-    sh, '-c', 'cp "@0@" "@1@"'.format(
+    'sh', '-c', 'cp "@0@" "@1@"'.format(
       cinnamon_css.full_path(),
       join_paths('$MESON_INSTALL_DESTDIR_PREFIX', cinnamon_dir, 'cinnamon.css'),
     ),

--- a/src/gnome-shell/meson.build
+++ b/src/gnome-shell/meson.build
@@ -132,7 +132,7 @@ foreach theme: themes
 
   # Install it while renaming to a valid name
   meson.add_install_script(
-    sh, '-c', 'cp "@0@" "@1@"'.format(
+    'sh', '-c', 'cp "@0@" "@1@"'.format(
       gnome_shell_css.full_path(),
       join_paths('$MESON_INSTALL_DESTDIR_PREFIX', gnome_shell_dir, 'gnome-shell.css'),
     ),

--- a/src/gtk-3.0/meson.build
+++ b/src/gtk-3.0/meson.build
@@ -71,7 +71,7 @@ foreach theme: themes
 
     # Install it while renaming to a valid name
     meson.add_install_script(
-      sh, '-c', 'cp "@0@" "@1@"'.format(
+      'sh', '-c', 'cp "@0@" "@1@"'.format(
         gtk3_css.full_path(),
         join_paths('$MESON_INSTALL_DESTDIR_PREFIX', gtk3_dir, 'gtk@0@.css'.format(gtk3_variant)),
       ),

--- a/src/gtk-4.0/meson.build
+++ b/src/gtk-4.0/meson.build
@@ -81,7 +81,7 @@ foreach theme: themes
 
     # Install it while renaming to a valid name
     meson.add_install_script(
-      sh, '-c', 'cp "@0@" "@1@"'.format(
+      'sh', '-c', 'cp "@0@" "@1@"'.format(
         gtk4_css.full_path(),
         join_paths('$MESON_INSTALL_DESTDIR_PREFIX', gtk4_dir, 'gtk@0@.css'.format(gtk4_variant)),
       ),


### PR DESCRIPTION
## Description

I'm getting error on building:
```
src/cinnamon/meson.build:55:8: ERROR: add_install_script args must be strings
```

## My system info
- ubuntu 20.04 (Focal Fossa)
- meson: v0.53.2 (retrieved from focal repositories)
- sassc: v3.6.1
- libsass: v3.6.3
- sass2scss: v1.1.1
- sass: v3.5

## Steps to reproduce the bug

1. `git clone https://github.com/nana-4/materia-theme.git`
2. `cd materia-theme`
3. `meson _build -Dprefix="$HOME/.local"`

## Actual behavior

I'm getting following error:

```
The Meson build system
Version: 0.53.2
Source dir: /home/ponpon/Materia
Build dir: /home/ponpon/Materia/_build
Build type: native build
Project name: materia-theme
Project version: 20200916
Host machine cpu family: x86_64
Host machine cpu: x86_64
Program sassc found: YES (/usr/bin/sassc)
Program sh found: YES (/usr/bin/sh)
Configuring Materia.index.theme using configuration
Configuring Materia-compact.index.theme using configuration
Configuring Materia-light.index.theme using configuration
Configuring Materia-light-compact.index.theme using configuration
Configuring Materia-dark.index.theme using configuration
Configuring Materia-dark-compact.index.theme using configuration
Configuring Materia.cinnamon.scss using configuration

src/cinnamon/meson.build:55:8: ERROR: add_install_script args must be strings
```

<details>
  <summary>Log file: _build/meson-logs/meson-log.txt</summary>

  ```
  Build started at 2021-03-21T20:22:29.052546
  Main binary: /usr/bin/python3
  Build Options: -Dprefix=/home/ponpon/.local
  Python system: Linux
  The Meson build system
  Version: 0.53.2
  Source dir: /home/ponpon/Materia
  Build dir: /home/ponpon/Materia/_build
  Build type: native build
  Project name: materia-theme
  Project version: 20200916
  Build machine cpu family: x86_64
  Build machine cpu: x86_64
  Host machine cpu family: x86_64
  Host machine cpu: x86_64
  Target machine cpu family: x86_64
  Target machine cpu: x86_64
  Program sassc found: YES (/usr/bin/sassc)
  Program sh found: YES (/usr/bin/sh)
  Configuring Materia.index.theme using configuration
  Configuring Materia-compact.index.theme using configuration
  Configuring Materia-light.index.theme using configuration
  Configuring Materia-light-compact.index.theme using configuration
  Configuring Materia-dark.index.theme using configuration
  Configuring Materia-dark-compact.index.theme using configuration
  Configuring Materia.cinnamon.scss using configuration
  Element not a string: [<Holder: <ExternalProgram 'sh' -> ['/usr/bin/sh']>>, '-c', 'cp "/home/ponpon/Projects/Materia/_build/src/cinnamon/Materia.cinnamon.css" "$MESON_INSTALL_DESTDIR_PREFIX/share/themes/Materia/cinnamon/cinnamon.css"']
  
  src/cinnamon/meson.build:55:8: ERROR: add_install_script args must be strings
  ```
</details>

## Expected behavior

Build process needs to be finished without any errors.

## Proposed solution

I just replaced `sh` with `"sh"` as a string in build scripts and it worked, built successfully and installed well.