### PR TITLE
build: Migrate from sassc to dart-sass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pem
 tmp/
 *build*/
+node_modules/

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,6 +1,6 @@
 ## Summary
 
-- To be able to use the latest/adequate version of Sass, install `sassc`.
+- To be able to use the latest/adequate version of Sass, install `dart-sass`.
 - `meson install` will regenerate the CSS every time you modify the SCSS files.
 - Note that Meson always builds out-of-tree, so the regenerated CSS files will
   appear in your builddir.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 Materia requires the following build and runtime dependencies:
 
 - `meson` >= 0.47.0
-- `sassc`
+- `dart-sass` >= 1.23.0 (or `npm` if the former is not found)
 - `gnome-themes-extra` (or `gnome-themes-standard` for older distributions)
 - Murrine engine — The package name depends on the distro:
   - `gtk-engine-murrine` on Arch Linux

--- a/meson.build
+++ b/meson.build
@@ -17,8 +17,21 @@ else
   sh = 'sh'
 endif
 
-sassc = find_program('sassc')
-sassc_opts = ['-M', '-t', 'expanded']
+sass = find_program('sass', required: false)
+sass_opts = ['--no-source-map']
+
+if sass.found()
+  sass_full_version = run_command(sass, '--version').stdout()
+  sass_is_ruby_sass = sass_full_version.contains('Ruby Sass')
+  sass_has_module_system = sass_full_version.version_compare('>= 1.23.0')
+endif
+
+if not sass.found() or sass_is_ruby_sass or not sass_has_module_system
+  message('dart-sass >= 1.23.0 not found, installing it locally via npm')
+  npm = find_program('npm')
+  run_command(npm, 'install')
+  sass = find_program('./node_modules/.bin/sass')
+endif
 
 themes = []
 foreach color: get_option('colors')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,141 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "chokidar": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.5.0"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
+    },
+    "readdirp": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
+    "sass": {
+      "version": "1.32.8",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.8.tgz",
+      "integrity": "sha512-Sl6mIeGpzjIUZqvKnKETfMf0iDAswD9TNlv13A7aAF3XZlRPMq4VvJWBC2N2DXbp94MQVdNSFG6LfF/iOXrPHQ==",
+      "dev": true,
+      "requires": {
+        "chokidar": ">=2.0.0 <4.0.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "sass": "^1.32.8"
+  }
+}

--- a/parse-sass.sh
+++ b/parse-sass.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 set -ueo pipefail
 
-if [[ ! "$(command -v sassc)" ]]; then
-  echo "'sassc' needs to be installed to generate the CSS."
+if [[ ! "$(command -v sass)" ]]; then
+  echo "'sass' needs to be installed to generate the CSS."
   exit 1
 fi
 
-SASSC_OPT=('-M' '-t' 'expanded')
+SASS_OPT=('--no-source-map')
 
 echo "Generating the chrome-scrollbar CSS..."
 
-sassc "${SASSC_OPT[@]}" src/chrome/chrome-scrollbar/scrollbars.{scss,css}
-sassc "${SASSC_OPT[@]}" src/chrome/chrome-scrollbar-dark/scrollbars.{scss,css}
+sass "${SASS_OPT[@]}" src/chrome/chrome-scrollbar/scrollbars.{scss,css}
+sass "${SASS_OPT[@]}" src/chrome/chrome-scrollbar-dark/scrollbars.{scss,css}

--- a/src/cinnamon/meson.build
+++ b/src/cinnamon/meson.build
@@ -46,7 +46,7 @@ foreach theme: themes
     '@0@.css'.format(cinnamon_temp_name),
     input: cinnamon_scss,
     output: '@0@.css'.format(cinnamon_temp_name),
-    command: [sassc, sassc_opts, '@INPUT@', '@OUTPUT@'],
+    command: [sass, sass_opts, '@INPUT@', '@OUTPUT@'],
     depend_files: cinnamon_scss_depend_files,
     build_by_default: true,
   )

--- a/src/gnome-shell/meson.build
+++ b/src/gnome-shell/meson.build
@@ -124,7 +124,7 @@ foreach theme: themes
     '@0@.css'.format(gnome_shell_temp_name),
     input: gnome_shell_scss,
     output: '@0@.css'.format(gnome_shell_temp_name),
-    command: [sassc, sassc_opts, '@INPUT@', '@OUTPUT@'],
+    command: [sass, sass_opts, '@INPUT@', '@OUTPUT@'],
     depend_files: gnome_shell_scss_depend_files,
     build_by_default: true,
   )

--- a/src/gtk-3.0/meson.build
+++ b/src/gtk-3.0/meson.build
@@ -64,7 +64,7 @@ foreach theme: themes
       '@0@.css'.format(gtk3_temp_name),
       input: gtk3_scss,
       output: '@0@.css'.format(gtk3_temp_name),
-      command: [sassc, sassc_opts, '@INPUT@', '@OUTPUT@'],
+      command: [sass, sass_opts, '@INPUT@', '@OUTPUT@'],
       depend_files: gtk3_scss_depend_files,
       build_by_default: true,
     )

--- a/src/gtk-4.0/meson.build
+++ b/src/gtk-4.0/meson.build
@@ -74,7 +74,7 @@ foreach theme: themes
       '@0@.css'.format(gtk4_temp_name),
       input: gtk4_scss,
       output: '@0@.css'.format(gtk4_temp_name),
-      command: [sassc, sassc_opts, '@INPUT@', '@OUTPUT@'],
+      command: [sass, sass_opts, '@INPUT@', '@OUTPUT@'],
       depend_files: gtk4_scss_depend_files,
       build_by_default: true,
     )


### PR DESCRIPTION
LibSass and SassC have been deprecated. Let's migrate to Dart Sass
as recommended by the Sass team. See:

https://sass-lang.com/blog/libsass-is-deprecated

Closes https://github.com/nana-4/materia-theme/issues/553