### PR TITLE
build: shebang  portability and fix build on *nix systems

### DIFF
--- a/parse-sass.sh
+++ b/parse-sass.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ueo pipefail
 
 if [[ ! "$(command -v sass)" ]]; then

--- a/render-assets.sh
+++ b/render-assets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ueo pipefail
 
 if [[ ! "$(command -v inkscape || command -v rendersvg)" ]]; then
@@ -31,31 +31,31 @@ gtk2_dark() (
 )
 
 case "${1:-}" in
-  "")
-    chrome
-    gtk
-    gtk2_light
-    gtk2_dark
-    ;;
-  chrome)
-    chrome
-    ;;
-  gtk)
-    gtk
-    ;;
-  gtk2)
-    gtk2_light
-    gtk2_dark
-    ;;
-  gtk2-light)
-    gtk2_light
-    ;;
-  gtk2-dark)
-    gtk2_dark
-    ;;
-  *)
-    echo "Unknown argument '$1'"
-    echo "Use 'chrome', 'gtk', 'gtk2', 'gtk2-light' or 'gtk2-dark' as an argument."
-    exit 1
-    ;;
+"")
+  chrome
+  gtk
+  gtk2_light
+  gtk2_dark
+  ;;
+chrome)
+  chrome
+  ;;
+gtk)
+  gtk
+  ;;
+gtk2)
+  gtk2_light
+  gtk2_dark
+  ;;
+gtk2-light)
+  gtk2_light
+  ;;
+gtk2-dark)
+  gtk2_dark
+  ;;
+*)
+  echo "Unknown argument '$1'"
+  echo "Use 'chrome', 'gtk', 'gtk2', 'gtk2-light' or 'gtk2-dark' as an argument."
+  exit 1
+  ;;
 esac

--- a/snapshot.sh
+++ b/snapshot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Create a snapshot for comparison with the latest development version.
 #

--- a/src/chrome/render-asset.sh
+++ b/src/chrome/render-asset.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ueo pipefail
 
 FORCE_INKSCAPE="$(echo "${FORCE_INKSCAPE-False}" | tr '[:upper:]' '[:lower:]')"
@@ -11,11 +11,11 @@ INKSCAPE="$(command -v inkscape)" || true
 OPTIPNG="$(command -v optipng)" || true
 
 if [[ -n "${INKSCAPE}" ]]; then
-  if "$INKSCAPE" --help | grep -e "--export-filename" > /dev/null; then
+  if "$INKSCAPE" --help | grep -e "--export-filename" >/dev/null; then
     EXPORT_FILE_OPTION="--export-filename"
-  elif "$INKSCAPE" --help | grep -e "--export-file" > /dev/null; then
+  elif "$INKSCAPE" --help | grep -e "--export-file" >/dev/null; then
     EXPORT_FILE_OPTION="--export-file"
-  elif "$INKSCAPE" --help | grep -e "--export-png" > /dev/null; then
+  elif "$INKSCAPE" --help | grep -e "--export-png" >/dev/null; then
     EXPORT_FILE_OPTION="--export-png"
   fi
 fi

--- a/src/chrome/render-assets.sh
+++ b/src/chrome/render-assets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ueo pipefail
 
 # Make sure that parallel is GNU parallel and not moreutils.
@@ -9,4 +9,4 @@ else
   cmd=(xargs -n1)
 fi
 
-"${cmd[@]}" ./render-asset.sh < assets.txt
+"${cmd[@]}" ./render-asset.sh <assets.txt

--- a/src/gtk-2.0/render-asset.sh
+++ b/src/gtk-2.0/render-asset.sh
@@ -1,21 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ueo pipefail
 
 FORCE_INKSCAPE="$(echo "${FORCE_INKSCAPE-False}" | tr '[:upper:]' '[:lower:]')"
 if [[ "${FORCE_INKSCAPE}" == "true" ]]; then
-	RENDER_SVG=""
+  RENDER_SVG=""
 else
-	RENDER_SVG="$(command -v rendersvg)" || true
+  RENDER_SVG="$(command -v rendersvg)" || true
 fi
 INKSCAPE="$(command -v inkscape)" || true
 OPTIPNG="$(command -v optipng)" || true
 
 if [[ -n "${INKSCAPE}" ]]; then
-  if "$INKSCAPE" --help | grep -e "--export-filename" > /dev/null; then
+  if "$INKSCAPE" --help | grep -e "--export-filename" >/dev/null; then
     EXPORT_FILE_OPTION="--export-filename"
-  elif "$INKSCAPE" --help | grep -e "--export-file" > /dev/null; then
+  elif "$INKSCAPE" --help | grep -e "--export-file" >/dev/null; then
     EXPORT_FILE_OPTION="--export-file"
-  elif "$INKSCAPE" --help | grep -e "--export-png" > /dev/null; then
+  elif "$INKSCAPE" --help | grep -e "--export-png" >/dev/null; then
     EXPORT_FILE_OPTION="--export-png"
   fi
 fi
@@ -45,14 +45,14 @@ echo "Rendering '$ASSETS_DIR/$i.png'"
 if [[ -n "${RENDER_SVG}" ]]; then
   # @TODO: remove --zoom when it will be fixed/implemented in resvg
   "$RENDER_SVG" --export-id "$i" \
-                --dpi ${DPI} \
-                --zoom ${ZOOM} \
-                "$SRC_FILE" "$ASSETS_DIR/$i.png"
+    --dpi ${DPI} \
+    --zoom ${ZOOM} \
+    "$SRC_FILE" "$ASSETS_DIR/$i.png"
 else
   "$INKSCAPE" --export-id="$i" \
-              --export-id-only \
-              --export-dpi=${DPI} \
-              "$EXPORT_FILE_OPTION=$ASSETS_DIR/$i.png" "$SRC_FILE" >/dev/null
+    --export-id-only \
+    --export-dpi=${DPI} \
+    "$EXPORT_FILE_OPTION=$ASSETS_DIR/$i.png" "$SRC_FILE" >/dev/null
 fi
 
 if [[ -n "${OPTIPNG}" ]]; then

--- a/src/gtk-2.0/render-assets.sh
+++ b/src/gtk-2.0/render-assets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ueo pipefail
 
 # Make sure that parallel is GNU parallel and not moreutils.
@@ -9,4 +9,4 @@ else
   cmd=(xargs -n1)
 fi
 
-"${cmd[@]}" ./render-asset.sh "$1" < assets.txt
+"${cmd[@]}" ./render-asset.sh "$1" <assets.txt

--- a/src/gtk-3.0/render-asset.sh
+++ b/src/gtk-3.0/render-asset.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ueo pipefail
 
 FORCE_INKSCAPE="$(echo "${FORCE_INKSCAPE-False}" | tr '[:upper:]' '[:lower:]')"
@@ -11,11 +11,11 @@ INKSCAPE="$(command -v inkscape)" || true
 OPTIPNG="$(command -v optipng)" || true
 
 if [[ -n "${INKSCAPE}" ]]; then
-  if "$INKSCAPE" --help | grep -e "--export-filename" > /dev/null; then
+  if "$INKSCAPE" --help | grep -e "--export-filename" >/dev/null; then
     EXPORT_FILE_OPTION="--export-filename"
-  elif "$INKSCAPE" --help | grep -e "--export-file" > /dev/null; then
+  elif "$INKSCAPE" --help | grep -e "--export-file" >/dev/null; then
     EXPORT_FILE_OPTION="--export-file"
-  elif "$INKSCAPE" --help | grep -e "--export-png" > /dev/null; then
+  elif "$INKSCAPE" --help | grep -e "--export-png" >/dev/null; then
     EXPORT_FILE_OPTION="--export-png"
   fi
 fi
@@ -29,11 +29,11 @@ echo "Rendering '$ASSETS_DIR/$i.png'"
 
 if [[ -n "${RENDER_SVG}" ]]; then
   "$RENDER_SVG" --export-id "$i" \
-                "$SRC_FILE" "$ASSETS_DIR/$i.png"
+    "$SRC_FILE" "$ASSETS_DIR/$i.png"
 else
   "$INKSCAPE" --export-id="$i" \
-              --export-id-only \
-              "$EXPORT_FILE_OPTION=$ASSETS_DIR/$i.png" "$SRC_FILE" >/dev/null
+    --export-id-only \
+    "$EXPORT_FILE_OPTION=$ASSETS_DIR/$i.png" "$SRC_FILE" >/dev/null
 fi
 
 if [[ -n "${OPTIPNG}" ]]; then
@@ -45,14 +45,14 @@ echo "Rendering '$ASSETS_DIR/$i@2.png'"
 if [[ -n "${RENDER_SVG}" ]]; then
   # @TODO: remove --zoom when it will be fixed/implemented in resvg
   "$RENDER_SVG" --export-id "$i" \
-                --dpi 192 \
-                --zoom 2 \
-                "$SRC_FILE" "$ASSETS_DIR/$i@2.png"
+    --dpi 192 \
+    --zoom 2 \
+    "$SRC_FILE" "$ASSETS_DIR/$i@2.png"
 else
   "$INKSCAPE" --export-id="$i" \
-              --export-id-only \
-              --export-dpi=192 \
-              "$EXPORT_FILE_OPTION=$ASSETS_DIR/$i@2.png" "$SRC_FILE" >/dev/null
+    --export-id-only \
+    --export-dpi=192 \
+    "$EXPORT_FILE_OPTION=$ASSETS_DIR/$i@2.png" "$SRC_FILE" >/dev/null
 fi
 
 if [[ -n "${OPTIPNG}" ]]; then

--- a/src/gtk-3.0/render-assets.sh
+++ b/src/gtk-3.0/render-assets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -ueo pipefail
 
 # Make sure that parallel is GNU parallel and not moreutils.
@@ -9,4 +9,4 @@ else
   cmd=(xargs -n1)
 fi
 
-"${cmd[@]}" ./render-asset.sh < assets.txt
+"${cmd[@]}" ./render-asset.sh <assets.txt


### PR DESCRIPTION
### Motivation

Make build on systems where bash may be outside of /bin reproducible.

By convention and [portability](https://en.wikipedia.org/w/index.php?title=Shebang_(Unix)&oldid=878552871#Portability)  is used #!/usr/bin/env bash.