### PR TITLE
gtk/chromium: Fix border between toolbar and page content being transparent

### DIFF
--- a/src/gtk-3.0/sass/apps/_misc.scss
+++ b/src/gtk-3.0/sass/apps/_misc.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @use "../../../theme";
 @use "../../../theme-color";
 @use "../../../shadow";
@@ -132,6 +133,10 @@ window.background.chromium {
 
   > button {
     color: theme-color.$primary;
+
+    // Source: https://github.com/heldplayer/materia-theme-custom/commit/93af85f1c775745e46f92673bc55edf39b179579
+    $this-border-color: theme-color.stroke(theme-color.$on-surface);
+    border-color: color.mix(rgba($this-border-color, 1), theme-color.$surface-z8, color.alpha($this-border-color) * 100%);
 
     &:disabled {
       color: theme-color.disabled-hint(theme-color.$on-surface);


### PR DESCRIPTION
This PR ports the patch found at https://github.com/heldplayer/materia-theme-custom/commit/93af85f1c775745e46f92673bc55edf39b179579

I've used materia for many years, I love the theme. I encountered this glitch which I found to be really annoying for the better part of 2022. Luckily I found this patch (credit to the author @heldplayer) which fixes the issue.